### PR TITLE
pkg/cmd/render: add static Pod support for etcd CAs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.11 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-etcd-operator
 COPY . .
 RUN go build ./cmd/cluster-etcd-operator


### PR DESCRIPTION
This PR adds two flags `--etcd-ca` and `etcd-metric-ca`. These flags take the input to the local CAs created by the installer and deploy them to `/etc/kubernetes/static-pod-resources/etcd-member` allowing etcd to start after signer client generates certs.

### updated example
```bash
    podman run \
    --quiet \
    --volume "$PWD:/assets:z" \
    --volume /etc/kubernetes:/etc/kubernetes:z \
    "${ETCD_OPERATOR_IMAGE}" \
    /usr/bin/cluster-etcd-operator render \
      --etcd-ca=/assets/tls/etcd-ca-bundle.crt \
      --etcd-metric-ca=/assets/tls/etcd-metric-ca-bundle.crt \
      --manifest-etcd-image "${ETCD_IMAGE}" \
      --etcd-discovery-domain "sbatsche.hexfusion.local" \
      --etcd-config-file /assets/etcd.conf \
      --manifest-setup-etcd-env-image "${MACHINE_CONFIG_SETUP_ETCD_ENV_IMAGE}" \
      --manifest-image-pull-policy "TEST" \
      --manifest-kube-client-agent-image "${KUBE_CLIENT_AGENT_IMAGE}" \
      --asset-input-dir=./assets/tls \
      --asset-output-dir=./assets/etcd-bootstrap \
      --config-output-file=./assets/etcd-bootstrap/config
```

Fixes https://github.com/hexfusion/cluster-etcd-operator/issues/7