### PR TITLE
pkg/operator, manifests: fix secret names, report success on install

### DIFF
--- a/manifests/0000_12_etcd-operator_06_deployment.yaml
+++ b/manifests/0000_12_etcd-operator_06_deployment.yaml
@@ -47,6 +47,8 @@ spec:
           value: quay.io/openshift/origin-hyperkube:v4.0
         - name: OPERATOR_IMAGE
           value: quay.io/openshift/cluster-etcd-operator:v4.0
+        - name: OPERATOR_IMAGE_VERSION
+          value: "0.0.1-snapshot"
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/manifests/0000_12_etcd-operator_07_clusteroperator.yaml
+++ b/manifests/0000_12_etcd-operator_07_clusteroperator.yaml
@@ -1,7 +1,7 @@
 apiVersion: config.openshift.io/v1
 kind: ClusterOperator
 metadata:
-  name: etcd
+  name: openshift-etcd
 spec: {}
 status:
   versions:

--- a/pkg/operator/clustermembercontroller/clustermembercontroller.go
+++ b/pkg/operator/clustermembercontroller/clustermembercontroller.go
@@ -84,6 +84,16 @@ func (c *ClusterMemberController) sync() error {
 		return err
 	}
 
+	//since the operator is running, it means the cluster etcd is available
+	availableCond := operatorv1.OperatorCondition{
+		Type:   operatorv1.OperatorStatusTypeAvailable,
+		Status: operatorv1.ConditionTrue,
+	}
+	if _, _, updateError := v1helpers.UpdateStatus(c.operatorConfigClient,
+		v1helpers.UpdateConditionFn(availableCond)); updateError != nil {
+		return updateError
+	}
+
 	for i := range pods.Items {
 		p := &pods.Items[i]
 		klog.Infof("Found etcd Pod with name %v\n", p.Name)

--- a/pkg/operator/etcdcertsigner/etcdcertsignercontroller_test.go
+++ b/pkg/operator/etcdcertsigner/etcdcertsignercontroller_test.go
@@ -177,3 +177,48 @@ func verify(a getCertArgs, cert *bytes.Buffer) error {
 
 	return e
 }
+
+func Test_getSecretName(t *testing.T) {
+	type args struct {
+		org     string
+		podFQDN string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		// TODO: Add test cases.
+		{
+			name: "server test case",
+			args: args{
+				org:     serverOrg,
+				podFQDN: "etcd-0.foo.bar",
+			},
+			want: "server-etcd-0.foo.bar",
+		},
+		{
+			name: "peer test case",
+			args: args{
+				org:     peerOrg,
+				podFQDN: "etcd-0.foo.bar",
+			},
+			want: "peer-etcd-0.foo.bar",
+		},
+		{
+			name: "metric test case",
+			args: args{
+				org:     metricOrg,
+				podFQDN: "etcd-0.foo.bar",
+			},
+			want: "metric-etcd-0.foo.bar",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getSecretName(tt.args.org, tt.args.podFQDN); got != tt.want {
+				t.Errorf("getSecretName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -80,7 +80,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 	)
 
 	versionRecorder := status.NewVersionGetter()
-	clusterOperator, err := configClient.ConfigV1().ClusterOperators().Get("etcd", metav1.GetOptions{})
+	clusterOperator, err := configClient.ConfigV1().ClusterOperators().Get("openshift-etcd", metav1.GetOptions{})
 	if err != nil && !errors.IsNotFound(err) {
 		return err
 	}
@@ -88,6 +88,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 		versionRecorder.SetVersion(version.Name, version.Version)
 	}
 	versionRecorder.SetVersion("raw-internal", status.VersionForOperatorFromEnv())
+	versionRecorder.SetVersion("operator", status.VersionForOperatorFromEnv())
 
 	clusterOperatorStatus := status.NewClusterOperatorStatusController(
 		"openshift-etcd",

--- a/pkg/operator/v430_00_assets/bindata.go
+++ b/pkg/operator/v430_00_assets/bindata.go
@@ -397,7 +397,7 @@ type bintree struct {
 
 var _bintree = &bintree{nil, map[string]*bintree{
 	"v4.3.0": {nil, map[string]*bintree{
-		"etcd": {nil, map[string]*bintree{
+		"openshift-etcd": {nil, map[string]*bintree{
 			"cm.yaml":              {v430EtcdCmYaml, map[string]*bintree{}},
 			"defaultconfig.yaml":   {v430EtcdDefaultconfigYaml, map[string]*bintree{}},
 			"ns.yaml":              {v430EtcdNsYaml, map[string]*bintree{}},


### PR DESCRIPTION
This PR makes the secret name compatible with what `kubecsr mount` expects. Also fixes the installer not succeding even if CEO has successfully bootstrapped.

Depends on hexfusion/machine-config-operator#2