### PR TITLE
*: refactor out data structures in a separate package

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -22,7 +22,7 @@ github.com/cloudflare/cfssl v0.0.0-20190716005913-5fc50ce768d7 h1:OUsO8iauYaRaeq
 github.com/cloudflare/cfssl v0.0.0-20190716005913-5fc50ce768d7/go.mod h1:yMWuSON2oQp+43nFtAV/uvKQIFpSPerB57DCt9t8sSA=
 github.com/coreos/bbolt v1.3.3 h1:n6AiVyVRKQFNb6mJlwESEvvLoDyiTzXX7ORAUlkeBdY=
 github.com/coreos/bbolt v1.3.3/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
-github.com/coreos/etcd v3.3.10+incompatible h1:KjVWqrZ5U0wa3CxY2AxlH6/UcB+PK2td1DcsYhA+HRs=
+github.com/coreos/etcd v3.3.10+incompatible h1:jFneRYjIvLMLhDLCzuTuU4rSJUjRplcJQ7pD7MnhC04=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0 h1:3Jm3tLmsgAYcjC+4Up7hJrFBPr+n7rAqYeSw/SZazuY=

--- a/pkg/cmd/staticpodcontroller/staticpodcontroller.go
+++ b/pkg/cmd/staticpodcontroller/staticpodcontroller.go
@@ -10,7 +10,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/openshift/cluster-etcd-operator/pkg/operator/clustermembercontroller"
+	ceoapi "github.com/openshift/cluster-etcd-operator/pkg/operator/api"
+
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/operatorclient"
 	"github.com/openshift/cluster-etcd-operator/pkg/version"
 	"github.com/openshift/library-go/pkg/operator/events"
@@ -216,14 +217,14 @@ func (c *StaticPodController) IsMemberRemove(name string) bool {
 	members, _ := c.PendingMemberList()
 	for _, m := range members {
 		klog.Warningf("IsMemberRemove: checking %v vs %v type = %v\n", m.Name, name, m.Conditions[0].Type)
-		if m.Name == name && m.Conditions[0].Type == clustermembercontroller.MemberRemove {
+		if m.Name == name && m.Conditions[0].Type == ceoapi.MemberRemove {
 			return true
 		}
 	}
 	return false
 }
 
-func (c *StaticPodController) PendingMemberList() ([]clustermembercontroller.Member, error) {
+func (c *StaticPodController) PendingMemberList() ([]ceoapi.Member, error) {
 	configPath := []string{"cluster", "pending"}
 	operatorSpec, _, _, err := c.operatorConfigClient.GetOperatorState()
 	if err != nil {
@@ -242,7 +243,7 @@ func (c *StaticPodController) PendingMemberList() ([]clustermembercontroller.Mem
 	}
 
 	// populate current etcd members as observed.
-	var members []clustermembercontroller.Member
+	var members []ceoapi.Member
 	for _, member := range data {
 		memberMap, _ := member.(map[string]interface{})
 		name, exists, err := unstructured.NestedString(memberMap, "name")
@@ -267,11 +268,11 @@ func (c *StaticPodController) PendingMemberList() ([]clustermembercontroller.Mem
 			return nil, fmt.Errorf("member status does not exist")
 		}
 
-		condition := clustermembercontroller.GetMemberCondition(status)
-		m := clustermembercontroller.Member{
+		condition := ceoapi.GetMemberCondition(status)
+		m := ceoapi.Member{
 			Name:     name,
 			PeerURLS: []string{peerURLs},
-			Conditions: []clustermembercontroller.MemberCondition{
+			Conditions: []ceoapi.MemberCondition{
 				{
 					Type: condition,
 				},

--- a/pkg/operator/api/scaling.go
+++ b/pkg/operator/api/scaling.go
@@ -47,6 +47,8 @@ const (
 	MemberDegraded MemberConditionType = "Degraded"
 	// Remove indicates the member should be removed from the cluster
 	MemberRemove MemberConditionType = "Remove"
+	// MemberAdd is a member who is ready to join cluster but currently has not.
+	MemberAdd MemberConditionType = "Add"
 )
 
 func GetMemberCondition(status string) MemberConditionType {

--- a/pkg/operator/api/scaling.go
+++ b/pkg/operator/api/scaling.go
@@ -1,4 +1,4 @@
-package ceoutils
+package api
 
 import (
 	v1 "github.com/openshift/api/config/v1"

--- a/pkg/operator/ceoutils/scaling.go
+++ b/pkg/operator/ceoutils/scaling.go
@@ -1,0 +1,64 @@
+package ceoutils
+
+import (
+	v1 "github.com/openshift/api/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type EtcdScaling struct {
+	Metadata *metav1.ObjectMeta `json:"metadata,omitempty"`
+	Members  []Member           `json:"members,omitempty"`
+	PodFQDN  string             `json:"podFQDN,omitempty"`
+}
+
+type Member struct {
+	ID         uint64            `json:"ID,omitempty"`
+	Name       string            `json:"name,omitempty"`
+	PeerURLS   []string          `json:"peerURLs,omitempty"`
+	ClientURLS []string          `json:"clientURLs,omitempty"`
+	Conditions []MemberCondition `json:"conditions,omitempty"`
+}
+
+type MemberCondition struct {
+	// type describes the current condition
+	Type MemberConditionType `json:"type"`
+	// status is the status of the condition (True, False, Unknown)
+	Status v1.ConditionStatus `json:"status"`
+	// timestamp for the last update to this condition
+	// +optional
+	LastUpdateTime metav1.Time `json:"lastUpdateTime,omitempty"`
+	// reason is the reason for the condition's last transition.
+	// +optional
+	Reason string `json:"reason,omitempty"`
+	// message is a human-readable explanation containing details about
+	// the transition
+	// +optional
+	Message string `json:"message,omitempty"`
+}
+
+type MemberConditionType string
+
+const (
+	// Ready indicated the member is part of the cluster and available
+	MemberReady MemberConditionType = "Ready"
+	// Unknown indicated the member is part of the cluster but condition is unknown
+	MemberUnknown MemberConditionType = "Unknown"
+	// Degraded indicates the member pod is in a degraded state and should be restarted
+	MemberDegraded MemberConditionType = "Degraded"
+	// Remove indicates the member should be removed from the cluster
+	MemberRemove MemberConditionType = "Remove"
+)
+
+func GetMemberCondition(status string) MemberConditionType {
+	switch {
+	case status == string(MemberReady):
+		return MemberReady
+	case status == string(MemberRemove):
+		return MemberRemove
+	case status == string(MemberUnknown):
+		return MemberUnknown
+	case status == string(MemberDegraded):
+		return MemberDegraded
+	}
+	return ""
+}

--- a/pkg/operator/configobservation/etcd/observe_etcd.go
+++ b/pkg/operator/configobservation/etcd/observe_etcd.go
@@ -503,7 +503,7 @@ func getMembersFromConfig(config []interface{}) ([]ceoutils.Member, error) {
 	return members, nil
 }
 
-func setBootstrapMember(listers configobservation.Listers, etcdURLs []interface{}, recorder events.Recorder) ([]interface{}, error) {
+func setBootstrapMember(listers configobservation.Listers, etcdURLs []interface{}, recorder events.Recorder) (interface{}, error) {
 	endpoints, err := listers.OpenshiftEtcdEndpointsLister.Endpoints(etcdEndpointNamespace).Get(etcdHostEndpointName)
 	if errors.IsNotFound(err) {
 		recorder.Warningf("setBootstrapMember", "Required %s/%s endpoint not found", etcdEndpointNamespace, etcdHostEndpointName)
@@ -529,11 +529,11 @@ func setBootstrapMember(listers configobservation.Listers, etcdURLs []interface{
 				if err != nil {
 					return nil, err
 				}
-				etcdURLs = append(etcdURLs, etcdURL)
+				return etcdURL, nil
 			}
 		}
 	}
-	return etcdURLs, nil
+	return nil, fmt.Errorf("etcd-bootstrap endpoint does not exist")
 }
 
 func setMember(name string, peerURLs []string, status ceoutils.MemberConditionType) (map[string]interface{}, error) {

--- a/pkg/operator/configobservation/etcd/observe_etcd.go
+++ b/pkg/operator/configobservation/etcd/observe_etcd.go
@@ -103,7 +103,7 @@ func ObserveClusterMembers(genericListers configobserver.Listers, recorder event
 			if errors.IsNotFound(err) {
 				// if the node is no londer available we use the endpoint observatiopn
 				klog.Warningf("error: Node %s not found: adding remove status to %s ", nodeName, previousMember.Name)
-				clusterMember, err := setMember(previousMember.Name, previousMember.PeerURLS, clustermembercontroller.MemberRemove)
+				clusterMember, err := setMember(previousMember.Name, previousMember.PeerURLS, ceoapi.MemberRemove)
 				if err != nil {
 					return existingConfig, append(errs, err)
 
@@ -113,7 +113,7 @@ func ObserveClusterMembers(genericListers configobserver.Listers, recorder event
 			}
 			if node.Status.Conditions != nil && node.Status.Conditions[0].Type != "NodeStatusUnknown" || node.Status.Conditions[0].Type != "NodeStatusDown" {
 				klog.Warningf("Node Condition not expected %s:", node.Status.Conditions[0].Type)
-				clusterMember, err := setMember(previousMember.Name, previousMember.PeerURLS, clustermembercontroller.MemberUnknown)
+				clusterMember, err := setMember(previousMember.Name, previousMember.PeerURLS, ceoapi.MemberUnknown)
 				if err != nil {
 					return existingConfig, append(errs, err)
 				}
@@ -168,7 +168,7 @@ func ObservePendingClusterMembers(genericListers configobserver.Listers, recorde
 	}
 	for _, subset := range etcdEndpoints.Subsets {
 		for _, address := range subset.NotReadyAddresses {
-			status := clustermembercontroller.MemberAdd
+			status := ceoapi.MemberAdd
 			etcdURL := map[string]interface{}{}
 			name := address.TargetRef.Name
 
@@ -181,7 +181,7 @@ func ObservePendingClusterMembers(genericListers configobserver.Listers, recorde
 			}
 			if pod.Status.ContainerStatuses[0].State.Waiting != nil && pod.Status.ContainerStatuses[0].State.Waiting.Reason == "CrashLoopBackOff" {
 				if isPodCrashLoop(listers, name) {
-					status = clustermembercontroller.MemberRemove
+					status = ceoapi.MemberRemove
 				}
 			}
 			peerURLs := fmt.Sprintf("https://%s:2380", address.IP)
@@ -362,7 +362,7 @@ func (e *etcdObserver) setBootstrapMember() error {
 			if address.Hostname == "etcd-bootstrap" {
 				name := address.Hostname
 				peerURLs := fmt.Sprintf("https://%s.%s:2380", name, dnsSuffix)
-				clusterMember, err := setMember(name, []string{peerURLs}, clustermembercontroller.MemberUnknown)
+				clusterMember, err := setMember(name, []string{peerURLs}, ceoapi.MemberUnknown)
 				if err != nil {
 					return err
 				}
@@ -388,7 +388,7 @@ func (e *etcdObserver) setObserverdMembersFromEndpoint() error {
 		for _, address := range subset.Addresses {
 			name := address.TargetRef.Name
 			peerURLs := fmt.Sprintf("https://%s:2380", address.IP)
-			clusterMember, err := setMember(name, []string{peerURLs}, clustermembercontroller.MemberReady)
+			clusterMember, err := setMember(name, []string{peerURLs}, ceoapi.MemberReady)
 			if err != nil {
 				return err
 			}
@@ -401,7 +401,7 @@ func (e *etcdObserver) setObserverdMembersFromEndpoint() error {
 }
 
 func (e *etcdObserver) setObserverdPendingFromEndpoint() error {
-	status := clustermembercontroller.MemberAdd
+	status := ceoapi.MemberAdd
 
 	endpoints, err := e.listers.OpenshiftEtcdEndpointsLister.Endpoints(etcdEndpointNamespace).Get(etcdEndpointName)
 	if errors.IsNotFound(err) {
@@ -422,7 +422,7 @@ func (e *etcdObserver) setObserverdPendingFromEndpoint() error {
 			}
 			if pod.Status.ContainerStatuses[0].State.Waiting != nil && pod.Status.ContainerStatuses[0].State.Waiting.Reason == "CrashLoopBackOff" {
 				if isPodCrashLoop(e.listers, name) {
-					status = clustermembercontroller.MemberRemove
+					status = ceoapi.MemberRemove
 				}
 			}
 			peerURLs := fmt.Sprintf("https://%s:2380", address.IP)
@@ -437,7 +437,7 @@ func (e *etcdObserver) setObserverdPendingFromEndpoint() error {
 	return nil
 }
 
-func (e *etcdObserver) isPendingRemoval(members clustermembercontroller.Member, existingConfig map[string]interface{}) (bool, error) {
+func (e *etcdObserver) isPendingRemoval(members ceoapi.Member, existingConfig map[string]interface{}) (bool, error) {
 	previousPendingObserved, found, err := unstructured.NestedSlice(existingConfig, e.pendingPath...)
 	if err != nil {
 		return false, err
@@ -452,7 +452,7 @@ func (e *etcdObserver) isPendingRemoval(members clustermembercontroller.Member, 
 			if pendingMember.Conditions == nil {
 				return false, nil
 			}
-			if pendingMember.Name == members.Name && pendingMember.Conditions[0].Type == clustermembercontroller.MemberRemove {
+			if pendingMember.Name == members.Name && pendingMember.Conditions[0].Type == ceoapi.MemberRemove {
 				return true, nil
 			}
 		}
@@ -503,39 +503,6 @@ func getMembersFromConfig(config []interface{}) ([]ceoapi.Member, error) {
 	return members, nil
 }
 
-func setBootstrapMember(listers configobservation.Listers, etcdURLs []interface{}, recorder events.Recorder) (interface{}, error) {
-	endpoints, err := listers.OpenshiftEtcdEndpointsLister.Endpoints(etcdEndpointNamespace).Get(etcdHostEndpointName)
-	if errors.IsNotFound(err) {
-		recorder.Warningf("setBootstrapMember", "Required %s/%s endpoint not found", etcdEndpointNamespace, etcdHostEndpointName)
-		return nil, err
-	}
-	if err != nil {
-		recorder.Warningf("setBootstrapMember", "Error getting %s/%s endpoint: %v", etcdEndpointNamespace, etcdHostEndpointName, err)
-		return nil, err
-	}
-	dnsSuffix := endpoints.Annotations["alpha.installer.openshift.io/dns-suffix"]
-	if len(dnsSuffix) == 0 {
-		err := fmt.Errorf("endpoints %s/%s: alpha.installer.openshift.io/dns-suffix annotation not found", etcdEndpointNamespace, etcdHostEndpointName)
-		recorder.Warning("setBootstrapMember", err.Error())
-		return nil, err
-	}
-
-	for _, subset := range endpoints.Subsets {
-		for _, address := range subset.Addresses {
-			if address.Hostname == "etcd-bootstrap" {
-				name := address.Hostname
-				peerURLs := fmt.Sprintf("https://%s.%s:2380", name, dnsSuffix)
-				etcdURL, err := setMember(name, []string{peerURLs}, ceoapi.MemberUnknown)
-				if err != nil {
-					return nil, err
-				}
-				return etcdURL, nil
-			}
-		}
-	}
-	return nil, fmt.Errorf("etcd-bootstrap endpoint does not exist")
-}
-
 func setMember(name string, peerURLs []string, status ceoapi.MemberConditionType) (interface{}, error) {
 	etcdURL := map[string]interface{}{}
 	if err := unstructured.SetNestedField(etcdURL, name, "name"); err != nil {
@@ -548,16 +515,4 @@ func setMember(name string, peerURLs []string, status ceoapi.MemberConditionType
 		return nil, err
 	}
 	return etcdURL, nil
-}
-
-func isPendingRemoval(members ceoapi.Member, pending []ceoapi.Member) bool {
-	for _, pendingMember := range pending {
-		if pendingMember.Conditions == nil {
-			return false
-		}
-		if pendingMember.Name == members.Name && pendingMember.Conditions[0].Type == ceoapi.MemberRemove {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/operator/etcdcertsigner/etcdcertsignercontroller.go
+++ b/pkg/operator/etcdcertsigner/etcdcertsignercontroller.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/openshift/cluster-etcd-operator/pkg/operator/ceoutils"
+	ceoapi "github.com/openshift/cluster-etcd-operator/pkg/operator/api"
 
 	"strings"
 	"time"
@@ -109,7 +109,7 @@ func (c *EtcdCertSignerController) sync() error {
 		klog.Errorf("error getting configmap %#v\n", err)
 		return err
 	}
-	scaling := &ceoutils.EtcdScaling{}
+	scaling := &ceoapi.EtcdScaling{}
 	membershipData, ok := cm.Annotations[clustermembercontroller.EtcdScalingAnnotationKey]
 	if !ok {
 		// Scaling key not found in configmap, hence do nothing

--- a/pkg/operator/etcdcertsigner/etcdcertsignercontroller.go
+++ b/pkg/operator/etcdcertsigner/etcdcertsignercontroller.go
@@ -8,12 +8,15 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/openshift/cluster-etcd-operator/pkg/operator/ceoutils"
+
+	"strings"
+	"time"
+
 	"github.com/openshift/library-go/pkg/crypto"
 	"k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"strings"
-	"time"
 
 	"github.com/openshift/cluster-etcd-operator/pkg/operator/clustermembercontroller"
 	"github.com/openshift/library-go/pkg/operator/events"
@@ -106,7 +109,7 @@ func (c *EtcdCertSignerController) sync() error {
 		klog.Errorf("error getting configmap %#v\n", err)
 		return err
 	}
-	scaling := &clustermembercontroller.EtcdScaling{}
+	scaling := &ceoutils.EtcdScaling{}
 	membershipData, ok := cm.Annotations[clustermembercontroller.EtcdScalingAnnotationKey]
 	if !ok {
 		// Scaling key not found in configmap, hence do nothing


### PR DESCRIPTION
This helps in using the same packages across different projects,
so whenever we make a change it does not need to be copy-pasted across.

Also fixes a bug in observationconfig, the setBootstrapMember was returning
a list of members and it was later getting added to etcdURLs making it a list of 
lists. The lookup on bootstrap member was failing because of this giving error, 
`member name does not exists`