### PR TITLE
*: Add logic to teardown bootstrap

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,7 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.3
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 // indirect
-	github.com/vincent-petithory/dataurl v0.0.0-20160330182126-9a301d65acbb // indirect
+	github.com/vincent-petithory/dataurl v0.0.0-20160330182126-9a301d65acbb
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
 	github.com/zmap/zcrypto v0.0.0-20190711184618-e267965e6343 // indirect
 	github.com/zmap/zlint v0.0.0-20190720015309-a0632adea60b // indirect

--- a/pkg/operator/bootstrapteardown/teardown.go
+++ b/pkg/operator/bootstrapteardown/teardown.go
@@ -1,0 +1,65 @@
+package bootstrapteardown
+
+import (
+	"context"
+
+	"k8s.io/client-go/rest"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-etcd-operator/pkg/operator/clustermembercontroller"
+	cov1helpers "github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	clientwatch "k8s.io/client-go/tools/watch"
+	"k8s.io/klog"
+
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
+)
+
+func TearDownBootstrap(config *rest.Config,
+	clusterMemberShipController *clustermembercontroller.ClusterMemberController) error {
+	failing := configv1.ClusterStatusConditionType("Failing")
+	var lastError string
+	var err error
+
+	cc := configclient.NewForConfigOrDie(config)
+	_, err = clientwatch.UntilWithSync(
+		context.Background(),
+		cache.NewListWatchFromClient(cc.ConfigV1().RESTClient(), "clusterversions", "", fields.OneTermEqualSelector("metadata.name", "version")),
+		&configv1.ClusterVersion{},
+		nil,
+		func(event watch.Event) (bool, error) {
+			switch event.Type {
+			case watch.Added, watch.Modified:
+				cv, ok := event.Object.(*configv1.ClusterVersion)
+				if !ok {
+					klog.Warningf("Expected a ClusterVersion object but got a %q object instead", event.Object.GetObjectKind().GroupVersionKind())
+					return false, nil
+				}
+				if cov1helpers.IsStatusConditionTrue(cv.Status.Conditions, configv1.OperatorAvailable) {
+					return true, nil
+				}
+				if cov1helpers.IsStatusConditionTrue(cv.Status.Conditions, failing) {
+					lastError = cov1helpers.FindStatusCondition(cv.Status.Conditions, failing).Message
+				} else if cov1helpers.IsStatusConditionTrue(cv.Status.Conditions, configv1.OperatorProgressing) {
+					lastError = cov1helpers.FindStatusCondition(cv.Status.Conditions, configv1.OperatorProgressing).Message
+				}
+				klog.Errorf("Still waiting for the cluster to initialize: %s", lastError)
+				return false, nil
+			}
+			klog.Infof("Still waiting for the cluster to initialize...")
+			return false, nil
+		},
+	)
+
+	if err == nil {
+		klog.Infof("clusterversions is available, safe to remove bootstrap")
+		if clusterMemberShipController.IsMember("etcd-bootstrap") {
+			return clusterMemberShipController.RemoveBootstrap()
+		}
+		return nil
+	}
+
+	return nil
+}

--- a/pkg/operator/clustermembercontroller/clustermembercontroller_test.go
+++ b/pkg/operator/clustermembercontroller/clustermembercontroller_test.go
@@ -1,0 +1,91 @@
+package clustermembercontroller
+
+import (
+	"github.com/openshift/cluster-etcd-operator/pkg/operator/configobservation/etcd"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"testing"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/util/workqueue"
+)
+
+func TestClusterMemberController_RemoveBootstrapFromEndpoint(t *testing.T) {
+
+	client := fake.NewSimpleClientset()
+
+	addressList := []v1.EndpointAddress{
+		{
+			IP:       "192.168.2.1",
+			Hostname: "etcd-bootstrap",
+		},
+		{
+			IP:       "192.168.2.2",
+			Hostname: "etcd-1",
+		},
+		{
+			IP:       "192.168.2.3",
+			Hostname: "etcd-2",
+		},
+		{
+			IP:       "192.168.2.4",
+			Hostname: "etcd-3",
+		},
+	}
+	ep := &v1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      etcd.EtcdHostEndpointName,
+			Namespace: etcd.EtcdEndpointNamespace,
+		},
+		Subsets: []v1.EndpointSubset{
+			{
+				Addresses: addressList,
+			},
+		},
+	}
+
+	_, err := client.CoreV1().Endpoints(etcd.EtcdEndpointNamespace).Create(ep)
+	if err != nil {
+		t.Fatal()
+	}
+
+	type fields struct {
+		clientset            kubernetes.Interface
+		operatorConfigClient v1helpers.OperatorClient
+		queue                workqueue.RateLimitingInterface
+		eventRecorder        events.Recorder
+		etcdDiscoveryDomain  string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			name: "remove 0th address",
+			fields: fields{
+				clientset:           client,
+				etcdDiscoveryDomain: "",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &ClusterMemberController{
+				clientset:            tt.fields.clientset,
+				operatorConfigClient: tt.fields.operatorConfigClient,
+				queue:                tt.fields.queue,
+				eventRecorder:        tt.fields.eventRecorder,
+				etcdDiscoveryDomain:  tt.fields.etcdDiscoveryDomain,
+			}
+			if err := c.RemoveBootstrapFromEndpoint(); (err != nil) != tt.wantErr {
+				t.Errorf("RemoveBootstrapFromEndpoint() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/operator/configobservation/etcd/observe_etcd.go
+++ b/pkg/operator/configobservation/etcd/observe_etcd.go
@@ -20,9 +20,9 @@ import (
 )
 
 const (
-	etcdEndpointNamespace = "openshift-etcd"
-	etcdHostEndpointName  = "host-etcd"
-	etcdEndpointName      = "etcd"
+	EtcdEndpointNamespace = "openshift-etcd"
+	EtcdHostEndpointName  = "host-etcd"
+	EtcdEndpointName      = "etcd"
 )
 
 type etcdObserver struct {
@@ -92,7 +92,7 @@ func ObserveClusterMembers(genericListers configobserver.Listers, recorder event
 		if observer.HealthyMember[previousMember.Name] || previousMember.Name == "etcd-bootstrap" {
 			continue
 		}
-		_, err := observer.listers.OpenshiftEtcdPodsLister.Pods(etcdEndpointNamespace).Get(previousMember.Name)
+		_, err := observer.listers.OpenshiftEtcdPodsLister.Pods(EtcdEndpointNamespace).Get(previousMember.Name)
 		if errors.IsNotFound(err) {
 			// verify the node exists
 			//TODO this is very opnionated could this come from the endpoint?
@@ -155,14 +155,14 @@ func ObservePendingClusterMembers(genericListers configobserver.Listers, recorde
 	}
 
 	var etcdURLs []interface{}
-	etcdEndpoints, err := listers.OpenshiftEtcdEndpointsLister.Endpoints(etcdEndpointNamespace).Get(etcdEndpointName)
+	etcdEndpoints, err := listers.OpenshiftEtcdEndpointsLister.Endpoints(EtcdEndpointNamespace).Get(EtcdEndpointName)
 	if errors.IsNotFound(err) {
-		recorder.Warningf("ObservePendingClusterMembers", "Required %s/%s endpoint not found", etcdEndpointNamespace, etcdEndpointName)
+		recorder.Warningf("ObservePendingClusterMembers", "Required %s/%s endpoint not found", EtcdEndpointNamespace, EtcdEndpointName)
 		errs = append(errs, fmt.Errorf("endpoints/etcd.openshift-etcd: not found"))
 		return
 	}
 	if err != nil {
-		recorder.Warningf("ObservePendingClusterMembers", "Error getting %s/%s endpoint: %v", etcdEndpointNamespace, etcdEndpointName, err)
+		recorder.Warningf("ObservePendingClusterMembers", "Error getting %s/%s endpoint: %v", EtcdEndpointNamespace, EtcdEndpointName, err)
 		errs = append(errs, err)
 		return
 	}
@@ -176,7 +176,7 @@ func ObservePendingClusterMembers(genericListers configobserver.Listers, recorde
 			if err := unstructured.SetNestedField(etcdURL, name, "name"); err != nil {
 				return currentConfig, append(errs, err)
 			}
-			pod, err := listers.OpenshiftEtcdPodsLister.Pods(etcdEndpointNamespace).Get(name)
+			pod, err := listers.OpenshiftEtcdPodsLister.Pods(EtcdEndpointNamespace).Get(name)
 			if err != nil {
 				return currentConfig, append(errs, err)
 			}
@@ -239,20 +239,20 @@ func ObserveStorageURLs(genericListers configobserver.Listers, recorder events.R
 	}
 
 	var observerdClusterMembers []string
-	etcdEndpoints, err := listers.OpenshiftEtcdEndpointsLister.Endpoints(etcdEndpointNamespace).Get(etcdHostEndpointName)
+	etcdEndpoints, err := listers.OpenshiftEtcdEndpointsLister.Endpoints(EtcdEndpointNamespace).Get(EtcdHostEndpointName)
 	if errors.IsNotFound(err) {
-		recorder.Warningf("ObserveStorageFailed", "Required %s/%s endpoint not found", etcdEndpointNamespace, etcdHostEndpointName)
+		recorder.Warningf("ObserveStorageFailed", "Required %s/%s endpoint not found", EtcdEndpointNamespace, EtcdHostEndpointName)
 		errs = append(errs, fmt.Errorf("endpoints/host-etcd.openshift-etcd: not found"))
 		return
 	}
 	if err != nil {
-		recorder.Warningf("ObserveStorageFailed", "Error getting %s/%s endpoint: %v", etcdEndpointNamespace, etcdHostEndpointName, err)
+		recorder.Warningf("ObserveStorageFailed", "Error getting %s/%s endpoint: %v", EtcdEndpointNamespace, EtcdHostEndpointName, err)
 		errs = append(errs, err)
 		return
 	}
 	dnsSuffix := etcdEndpoints.Annotations["alpha.installer.openshift.io/dns-suffix"]
 	if len(dnsSuffix) == 0 {
-		dnsErr := fmt.Errorf("endpoints %s/%s: alpha.installer.openshift.io/dns-suffix annotation not found", etcdEndpointNamespace, etcdHostEndpointName)
+		dnsErr := fmt.Errorf("endpoints %s/%s: alpha.installer.openshift.io/dns-suffix annotation not found", EtcdEndpointNamespace, EtcdHostEndpointName)
 		recorder.Warning("ObserveStorageFailed", dnsErr.Error())
 		errs = append(errs, dnsErr)
 		return
@@ -260,7 +260,7 @@ func ObserveStorageURLs(genericListers configobserver.Listers, recorder events.R
 	for subsetIndex, subset := range etcdEndpoints.Subsets {
 		for addressIndex, address := range subset.Addresses {
 			if address.Hostname == "" {
-				addressErr := fmt.Errorf("endpoints %s/%s: subsets[%v]addresses[%v].hostname not found", etcdHostEndpointName, etcdEndpointNamespace, subsetIndex, addressIndex)
+				addressErr := fmt.Errorf("endpoints %s/%s: subsets[%v]addresses[%v].hostname not found", EtcdHostEndpointName, EtcdEndpointNamespace, subsetIndex, addressIndex)
 				recorder.Warningf("ObserveStorageFailed", addressErr.Error())
 				errs = append(errs, addressErr)
 				continue
@@ -270,7 +270,7 @@ func ObserveStorageURLs(genericListers configobserver.Listers, recorder events.R
 	}
 
 	if len(observerdClusterMembers) == 0 {
-		emptyURLErr := fmt.Errorf("endpoints %s/%s: no etcd endpoint addresses found", etcdEndpointNamespace, etcdHostEndpointName)
+		emptyURLErr := fmt.Errorf("endpoints %s/%s: no etcd endpoint addresses found", EtcdEndpointNamespace, EtcdHostEndpointName)
 		recorder.Warning("ObserveStorageFailed", emptyURLErr.Error())
 		errs = append(errs, emptyURLErr)
 	}
@@ -307,7 +307,7 @@ func isPodCrashLoop(listers configobservation.Listers, name string) bool {
 
 	// check if the pod is activly crashlooping we check etcd-member only at this time
 	if err := wait.PollImmediate(interval, timeout, func() (bool, error) {
-		pod, err := listers.OpenshiftEtcdPodsLister.Pods(etcdEndpointNamespace).Get(name)
+		pod, err := listers.OpenshiftEtcdPodsLister.Pods(EtcdEndpointNamespace).Get(name)
 		if err != nil {
 			klog.Errorf("unable to find pod %s: %v. Retrying.", name, err)
 			return false, nil
@@ -344,18 +344,18 @@ func isPodCrashLoop(listers configobservation.Listers, name string) bool {
 }
 
 func (e *etcdObserver) setBootstrapMember() error {
-	endpoints, err := e.listers.OpenshiftEtcdEndpointsLister.Endpoints(etcdEndpointNamespace).Get(etcdHostEndpointName)
+	endpoints, err := e.listers.OpenshiftEtcdEndpointsLister.Endpoints(EtcdEndpointNamespace).Get(EtcdHostEndpointName)
 	if errors.IsNotFound(err) {
-		e.recorder.Warningf("setBootstrapMember", "Required %s/%s endpoint not found", etcdEndpointNamespace, etcdHostEndpointName)
+		e.recorder.Warningf("setBootstrapMember", "Required %s/%s endpoint not found", EtcdEndpointNamespace, EtcdHostEndpointName)
 		return err
 	}
 	if err != nil {
-		e.recorder.Warningf("setBootstrapMember", "Error getting %s/%s endpoint: %v", etcdEndpointNamespace, etcdHostEndpointName, err)
+		e.recorder.Warningf("setBootstrapMember", "Error getting %s/%s endpoint: %v", EtcdEndpointNamespace, EtcdHostEndpointName, err)
 		return err
 	}
 	dnsSuffix := endpoints.Annotations["alpha.installer.openshift.io/dns-suffix"]
 	if len(dnsSuffix) == 0 {
-		err := fmt.Errorf("endpoints %s/%s: alpha.installer.openshift.io/dns-suffix annotation not found", etcdEndpointNamespace, etcdHostEndpointName)
+		err := fmt.Errorf("endpoints %s/%s: alpha.installer.openshift.io/dns-suffix annotation not found", EtcdEndpointNamespace, EtcdHostEndpointName)
 		e.recorder.Warning("setBootstrapMember", err.Error())
 		return err
 	}
@@ -377,13 +377,13 @@ func (e *etcdObserver) setBootstrapMember() error {
 }
 
 func (e *etcdObserver) setObserverdMembersFromEndpoint() error {
-	endpoints, err := e.listers.OpenshiftEtcdEndpointsLister.Endpoints(etcdEndpointNamespace).Get(etcdEndpointName)
+	endpoints, err := e.listers.OpenshiftEtcdEndpointsLister.Endpoints(EtcdEndpointNamespace).Get(EtcdEndpointName)
 	if errors.IsNotFound(err) {
-		e.recorder.Warningf("ObserveClusterMembers", "Required %s/%s endpoint not found", etcdEndpointNamespace, etcdHostEndpointName)
+		e.recorder.Warningf("ObserveClusterMembers", "Required %s/%s endpoint not found", EtcdEndpointNamespace, EtcdHostEndpointName)
 		return err
 	}
 	if err != nil {
-		e.recorder.Warningf("ObserveClusterMembers", "Error getting %s/%s endpoint: %v", etcdEndpointNamespace, etcdHostEndpointName, err)
+		e.recorder.Warningf("ObserveClusterMembers", "Error getting %s/%s endpoint: %v", EtcdEndpointNamespace, EtcdHostEndpointName, err)
 		return err
 	}
 
@@ -406,20 +406,20 @@ func (e *etcdObserver) setObserverdMembersFromEndpoint() error {
 func (e *etcdObserver) setObserverdPendingFromEndpoint() error {
 	status := ceoapi.MemberAdd
 
-	endpoints, err := e.listers.OpenshiftEtcdEndpointsLister.Endpoints(etcdEndpointNamespace).Get(etcdEndpointName)
+	endpoints, err := e.listers.OpenshiftEtcdEndpointsLister.Endpoints(EtcdEndpointNamespace).Get(EtcdEndpointName)
 	if errors.IsNotFound(err) {
-		e.recorder.Warningf("ObserveClusterPending", "Required %s/%s endpoint not found", etcdEndpointNamespace, etcdHostEndpointName)
+		e.recorder.Warningf("ObserveClusterPending", "Required %s/%s endpoint not found", EtcdEndpointNamespace, EtcdHostEndpointName)
 		return err
 	}
 	if err != nil {
-		e.recorder.Warningf("ObserveClusterPending", "Error getting %s/%s endpoint: %v", etcdEndpointNamespace, etcdHostEndpointName, err)
+		e.recorder.Warningf("ObserveClusterPending", "Error getting %s/%s endpoint: %v", EtcdEndpointNamespace, EtcdHostEndpointName, err)
 		return err
 	}
 
 	for _, subset := range endpoints.Subsets {
 		for _, address := range subset.NotReadyAddresses {
 			name := address.TargetRef.Name
-			pod, err := e.listers.OpenshiftEtcdPodsLister.Pods(etcdEndpointNamespace).Get(name)
+			pod, err := e.listers.OpenshiftEtcdPodsLister.Pods(EtcdEndpointNamespace).Get(name)
 			if err != nil {
 				return err
 			}

--- a/vendor/k8s.io/client-go/tools/watch/informerwatcher.go
+++ b/vendor/k8s.io/client-go/tools/watch/informerwatcher.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watch
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+)
+
+func newTicketer() *ticketer {
+	return &ticketer{
+		cond: sync.NewCond(&sync.Mutex{}),
+	}
+}
+
+type ticketer struct {
+	counter uint64
+
+	cond    *sync.Cond
+	current uint64
+}
+
+func (t *ticketer) GetTicket() uint64 {
+	// -1 to start from 0
+	return atomic.AddUint64(&t.counter, 1) - 1
+}
+
+func (t *ticketer) WaitForTicket(ticket uint64, f func()) {
+	t.cond.L.Lock()
+	defer t.cond.L.Unlock()
+	for ticket != t.current {
+		t.cond.Wait()
+	}
+
+	f()
+
+	t.current++
+	t.cond.Broadcast()
+}
+
+// NewIndexerInformerWatcher will create an IndexerInformer and wrap it into watch.Interface
+// so you can use it anywhere where you'd have used a regular Watcher returned from Watch method.
+// it also returns a channel you can use to wait for the informers to fully shutdown.
+func NewIndexerInformerWatcher(lw cache.ListerWatcher, objType runtime.Object) (cache.Indexer, cache.Controller, watch.Interface, <-chan struct{}) {
+	ch := make(chan watch.Event)
+	doneCh := make(chan struct{})
+	w := watch.NewProxyWatcher(ch)
+	t := newTicketer()
+
+	indexer, informer := cache.NewIndexerInformer(lw, objType, 0, cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			go t.WaitForTicket(t.GetTicket(), func() {
+				select {
+				case ch <- watch.Event{
+					Type:   watch.Added,
+					Object: obj.(runtime.Object),
+				}:
+				case <-w.StopChan():
+				}
+			})
+		},
+		UpdateFunc: func(old, new interface{}) {
+			go t.WaitForTicket(t.GetTicket(), func() {
+				select {
+				case ch <- watch.Event{
+					Type:   watch.Modified,
+					Object: new.(runtime.Object),
+				}:
+				case <-w.StopChan():
+				}
+			})
+		},
+		DeleteFunc: func(obj interface{}) {
+			go t.WaitForTicket(t.GetTicket(), func() {
+				staleObj, stale := obj.(cache.DeletedFinalStateUnknown)
+				if stale {
+					// We have no means of passing the additional information down using watch API based on watch.Event
+					// but the caller can filter such objects by checking if metadata.deletionTimestamp is set
+					obj = staleObj
+				}
+
+				select {
+				case ch <- watch.Event{
+					Type:   watch.Deleted,
+					Object: obj.(runtime.Object),
+				}:
+				case <-w.StopChan():
+				}
+			})
+		},
+	}, cache.Indexers{})
+
+	go func() {
+		defer close(doneCh)
+		informer.Run(w.StopChan())
+	}()
+
+	return indexer, informer, w, doneCh
+}

--- a/vendor/k8s.io/client-go/tools/watch/retrywatcher.go
+++ b/vendor/k8s.io/client-go/tools/watch/retrywatcher.go
@@ -1,0 +1,287 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+)
+
+// resourceVersionGetter is an interface used to get resource version from events.
+// We can't reuse an interface from meta otherwise it would be a cyclic dependency and we need just this one method
+type resourceVersionGetter interface {
+	GetResourceVersion() string
+}
+
+// RetryWatcher will make sure that in case the underlying watcher is closed (e.g. due to API timeout or etcd timeout)
+// it will get restarted from the last point without the consumer even knowing about it.
+// RetryWatcher does that by inspecting events and keeping track of resourceVersion.
+// Especially useful when using watch.UntilWithoutRetry where premature termination is causing issues and flakes.
+// Please note that this is not resilient to etcd cache not having the resource version anymore - you would need to
+// use Informers for that.
+type RetryWatcher struct {
+	lastResourceVersion string
+	watcherClient       cache.Watcher
+	resultChan          chan watch.Event
+	stopChan            chan struct{}
+	doneChan            chan struct{}
+	minRestartDelay     time.Duration
+}
+
+// NewRetryWatcher creates a new RetryWatcher.
+// It will make sure that watches gets restarted in case of recoverable errors.
+// The initialResourceVersion will be given to watch method when first called.
+func NewRetryWatcher(initialResourceVersion string, watcherClient cache.Watcher) (*RetryWatcher, error) {
+	return newRetryWatcher(initialResourceVersion, watcherClient, 1*time.Second)
+}
+
+func newRetryWatcher(initialResourceVersion string, watcherClient cache.Watcher, minRestartDelay time.Duration) (*RetryWatcher, error) {
+	switch initialResourceVersion {
+	case "", "0":
+		// TODO: revisit this if we ever get WATCH v2 where it means start "now"
+		//       without doing the synthetic list of objects at the beginning (see #74022)
+		return nil, fmt.Errorf("initial RV %q is not supported due to issues with underlying WATCH", initialResourceVersion)
+	default:
+		break
+	}
+
+	rw := &RetryWatcher{
+		lastResourceVersion: initialResourceVersion,
+		watcherClient:       watcherClient,
+		stopChan:            make(chan struct{}),
+		doneChan:            make(chan struct{}),
+		resultChan:          make(chan watch.Event, 0),
+		minRestartDelay:     minRestartDelay,
+	}
+
+	go rw.receive()
+	return rw, nil
+}
+
+func (rw *RetryWatcher) send(event watch.Event) bool {
+	// Writing to an unbuffered channel is blocking operation
+	// and we need to check if stop wasn't requested while doing so.
+	select {
+	case rw.resultChan <- event:
+		return true
+	case <-rw.stopChan:
+		return false
+	}
+}
+
+// doReceive returns true when it is done, false otherwise.
+// If it is not done the second return value holds the time to wait before calling it again.
+func (rw *RetryWatcher) doReceive() (bool, time.Duration) {
+	watcher, err := rw.watcherClient.Watch(metav1.ListOptions{
+		ResourceVersion: rw.lastResourceVersion,
+	})
+	// We are very unlikely to hit EOF here since we are just establishing the call,
+	// but it may happen that the apiserver is just shutting down (e.g. being restarted)
+	// This is consistent with how it is handled for informers
+	switch err {
+	case nil:
+		break
+
+	case io.EOF:
+		// watch closed normally
+		return false, 0
+
+	case io.ErrUnexpectedEOF:
+		klog.V(1).Infof("Watch closed with unexpected EOF: %v", err)
+		return false, 0
+
+	default:
+		msg := "Watch failed: %v"
+		if net.IsProbableEOF(err) {
+			klog.V(5).Infof(msg, err)
+			// Retry
+			return false, 0
+		}
+
+		klog.Errorf(msg, err)
+		// Retry
+		return false, 0
+	}
+
+	if watcher == nil {
+		klog.Error("Watch returned nil watcher")
+		// Retry
+		return false, 0
+	}
+
+	ch := watcher.ResultChan()
+	defer watcher.Stop()
+
+	for {
+		select {
+		case <-rw.stopChan:
+			klog.V(4).Info("Stopping RetryWatcher.")
+			return true, 0
+		case event, ok := <-ch:
+			if !ok {
+				klog.V(4).Infof("Failed to get event! Re-creating the watcher. Last RV: %s", rw.lastResourceVersion)
+				return false, 0
+			}
+
+			// We need to inspect the event and get ResourceVersion out of it
+			switch event.Type {
+			case watch.Added, watch.Modified, watch.Deleted:
+				metaObject, ok := event.Object.(resourceVersionGetter)
+				if !ok {
+					_ = rw.send(watch.Event{
+						Type:   watch.Error,
+						Object: &apierrors.NewInternalError(errors.New("retryWatcher: doesn't support resourceVersion")).ErrStatus,
+					})
+					// We have to abort here because this might cause lastResourceVersion inconsistency by skipping a potential RV with valid data!
+					return true, 0
+				}
+
+				resourceVersion := metaObject.GetResourceVersion()
+				if resourceVersion == "" {
+					_ = rw.send(watch.Event{
+						Type:   watch.Error,
+						Object: &apierrors.NewInternalError(fmt.Errorf("retryWatcher: object %#v doesn't support resourceVersion", event.Object)).ErrStatus,
+					})
+					// We have to abort here because this might cause lastResourceVersion inconsistency by skipping a potential RV with valid data!
+					return true, 0
+				}
+
+				// All is fine; send the event and update lastResourceVersion
+				ok = rw.send(event)
+				if !ok {
+					return true, 0
+				}
+				rw.lastResourceVersion = resourceVersion
+
+				continue
+
+			case watch.Error:
+				// This round trip allows us to handle unstructured status
+				errObject := apierrors.FromObject(event.Object)
+				statusErr, ok := errObject.(*apierrors.StatusError)
+				if !ok {
+					klog.Error(spew.Sprintf("Received an error which is not *metav1.Status but %#+v", event.Object))
+					// Retry unknown errors
+					return false, 0
+				}
+
+				status := statusErr.ErrStatus
+
+				statusDelay := time.Duration(0)
+				if status.Details != nil {
+					statusDelay = time.Duration(status.Details.RetryAfterSeconds) * time.Second
+				}
+
+				switch status.Code {
+				case http.StatusGone:
+					// Never retry RV too old errors
+					_ = rw.send(event)
+					return true, 0
+
+				case http.StatusGatewayTimeout, http.StatusInternalServerError:
+					// Retry
+					return false, statusDelay
+
+				default:
+					// We retry by default. RetryWatcher is meant to proceed unless it is certain
+					// that it can't. If we are not certain, we proceed with retry and leave it
+					// up to the user to timeout if needed.
+
+					// Log here so we have a record of hitting the unexpected error
+					// and we can whitelist some error codes if we missed any that are expected.
+					klog.V(5).Info(spew.Sprintf("Retrying after unexpected error: %#+v", event.Object))
+
+					// Retry
+					return false, statusDelay
+				}
+
+			default:
+				klog.Errorf("Failed to recognize Event type %q", event.Type)
+				_ = rw.send(watch.Event{
+					Type:   watch.Error,
+					Object: &apierrors.NewInternalError(fmt.Errorf("retryWatcher failed to recognize Event type %q", event.Type)).ErrStatus,
+				})
+				// We are unable to restart the watch and have to stop the loop or this might cause lastResourceVersion inconsistency by skipping a potential RV with valid data!
+				return true, 0
+			}
+		}
+	}
+}
+
+// receive reads the result from a watcher, restarting it if necessary.
+func (rw *RetryWatcher) receive() {
+	defer close(rw.doneChan)
+	defer close(rw.resultChan)
+
+	klog.V(4).Info("Starting RetryWatcher.")
+	defer klog.V(4).Info("Stopping RetryWatcher.")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		select {
+		case <-rw.stopChan:
+			cancel()
+			return
+		case <-ctx.Done():
+			return
+		}
+	}()
+
+	// We use non sliding until so we don't introduce delays on happy path when WATCH call
+	// timeouts or gets closed and we need to reestablish it while also avoiding hot loops.
+	wait.NonSlidingUntilWithContext(ctx, func(ctx context.Context) {
+		done, retryAfter := rw.doReceive()
+		if done {
+			cancel()
+			return
+		}
+
+		time.Sleep(retryAfter)
+
+		klog.V(4).Infof("Restarting RetryWatcher at RV=%q", rw.lastResourceVersion)
+	}, rw.minRestartDelay)
+}
+
+// ResultChan implements Interface.
+func (rw *RetryWatcher) ResultChan() <-chan watch.Event {
+	return rw.resultChan
+}
+
+// Stop implements Interface.
+func (rw *RetryWatcher) Stop() {
+	close(rw.stopChan)
+}
+
+// Done allows the caller to be notified when Retry watcher stops.
+func (rw *RetryWatcher) Done() <-chan struct{} {
+	return rw.doneChan
+}

--- a/vendor/k8s.io/client-go/tools/watch/until.go
+++ b/vendor/k8s.io/client-go/tools/watch/until.go
@@ -1,0 +1,236 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+)
+
+// PreconditionFunc returns true if the condition has been reached, false if it has not been reached yet,
+// or an error if the condition failed or detected an error state.
+type PreconditionFunc func(store cache.Store) (bool, error)
+
+// ConditionFunc returns true if the condition has been reached, false if it has not been reached yet,
+// or an error if the condition cannot be checked and should terminate. In general, it is better to define
+// level driven conditions over edge driven conditions (pod has ready=true, vs pod modified and ready changed
+// from false to true).
+type ConditionFunc func(event watch.Event) (bool, error)
+
+// ErrWatchClosed is returned when the watch channel is closed before timeout in UntilWithoutRetry.
+var ErrWatchClosed = errors.New("watch closed before UntilWithoutRetry timeout")
+
+// UntilWithoutRetry reads items from the watch until each provided condition succeeds, and then returns the last watch
+// encountered. The first condition that returns an error terminates the watch (and the event is also returned).
+// If no event has been received, the returned event will be nil.
+// Conditions are satisfied sequentially so as to provide a useful primitive for higher level composition.
+// Waits until context deadline or until context is canceled.
+//
+// Warning: Unless you have a very specific use case (probably a special Watcher) don't use this function!!!
+// Warning: This will fail e.g. on API timeouts and/or 'too old resource version' error.
+// Warning: You are most probably looking for a function *Until* or *UntilWithSync* below,
+// Warning: solving such issues.
+// TODO: Consider making this function private to prevent misuse when the other occurrences in our codebase are gone.
+func UntilWithoutRetry(ctx context.Context, watcher watch.Interface, conditions ...ConditionFunc) (*watch.Event, error) {
+	ch := watcher.ResultChan()
+	defer watcher.Stop()
+	var lastEvent *watch.Event
+	for _, condition := range conditions {
+		// check the next condition against the previous event and short circuit waiting for the next watch
+		if lastEvent != nil {
+			done, err := condition(*lastEvent)
+			if err != nil {
+				return lastEvent, err
+			}
+			if done {
+				continue
+			}
+		}
+	ConditionSucceeded:
+		for {
+			select {
+			case event, ok := <-ch:
+				if !ok {
+					return lastEvent, ErrWatchClosed
+				}
+				lastEvent = &event
+
+				done, err := condition(event)
+				if err != nil {
+					return lastEvent, err
+				}
+				if done {
+					break ConditionSucceeded
+				}
+
+			case <-ctx.Done():
+				return lastEvent, wait.ErrWaitTimeout
+			}
+		}
+	}
+	return lastEvent, nil
+}
+
+// Until wraps the watcherClient's watch function with RetryWatcher making sure that watcher gets restarted in case of errors.
+// The initialResourceVersion will be given to watch method when first called. It shall not be "" or "0"
+// given the underlying WATCH call issues (#74022). If you want the initial list ("", "0") done for you use ListWatchUntil instead.
+// Remaining behaviour is identical to function UntilWithoutRetry. (See above.)
+// Until can deal with API timeouts and lost connections.
+// It guarantees you to see all events and in the order they happened.
+// Due to this guarantee there is no way it can deal with 'Resource version too old error'. It will fail in this case.
+// (See `UntilWithSync` if you'd prefer to recover from all the errors including RV too old by re-listing
+//  those items. In normal code you should care about being level driven so you'd not care about not seeing all the edges.)
+// The most frequent usage for Until would be a test where you want to verify exact order of events ("edges").
+func Until(ctx context.Context, initialResourceVersion string, watcherClient cache.Watcher, conditions ...ConditionFunc) (*watch.Event, error) {
+	w, err := NewRetryWatcher(initialResourceVersion, watcherClient)
+	if err != nil {
+		return nil, err
+	}
+
+	return UntilWithoutRetry(ctx, w, conditions...)
+}
+
+// UntilWithSync creates an informer from lw, optionally checks precondition when the store is synced,
+// and watches the output until each provided condition succeeds, in a way that is identical
+// to function UntilWithoutRetry. (See above.)
+// UntilWithSync can deal with all errors like API timeout, lost connections and 'Resource version too old'.
+// It is the only function that can recover from 'Resource version too old', Until and UntilWithoutRetry will
+// just fail in that case. On the other hand it can't provide you with guarantees as strong as using simple
+// Watch method with Until. It can skip some intermediate events in case of watch function failing but it will
+// re-list to recover and you always get an event, if there has been a change, after recovery.
+// Also with the current implementation based on DeltaFIFO, order of the events you receive is guaranteed only for
+// particular object, not between more of them even it's the same resource.
+// The most frequent usage would be a command that needs to watch the "state of the world" and should't fail, like:
+// waiting for object reaching a state, "small" controllers, ...
+func UntilWithSync(ctx context.Context, lw cache.ListerWatcher, objType runtime.Object, precondition PreconditionFunc, conditions ...ConditionFunc) (*watch.Event, error) {
+	indexer, informer, watcher, done := NewIndexerInformerWatcher(lw, objType)
+	// We need to wait for the internal informers to fully stop so it's easier to reason about
+	// and it works with non-thread safe clients.
+	defer func() { <-done }()
+	// Proxy watcher can be stopped multiple times so it's fine to use defer here to cover alternative branches and
+	// let UntilWithoutRetry to stop it
+	defer watcher.Stop()
+
+	if precondition != nil {
+		if !cache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
+			return nil, fmt.Errorf("UntilWithSync: unable to sync caches: %v", ctx.Err())
+		}
+
+		done, err := precondition(indexer)
+		if err != nil {
+			return nil, err
+		}
+
+		if done {
+			return nil, nil
+		}
+	}
+
+	return UntilWithoutRetry(ctx, watcher, conditions...)
+}
+
+// ContextWithOptionalTimeout wraps context.WithTimeout and handles infinite timeouts expressed as 0 duration.
+func ContextWithOptionalTimeout(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if timeout < 0 {
+		// This should be handled in validation
+		klog.Errorf("Timeout for context shall not be negative!")
+		timeout = 0
+	}
+
+	if timeout == 0 {
+		return context.WithCancel(parent)
+	}
+
+	return context.WithTimeout(parent, timeout)
+}
+
+// ListWatchUntil first lists objects, converts them into synthetic ADDED events
+// and checks conditions for those synthetic events. If the conditions have not been reached so far
+// it continues by calling Until which establishes a watch from resourceVersion of the list call
+// to evaluate those conditions based on new events.
+// ListWatchUntil provides the same guarantees as Until and replaces the old WATCH from RV "" (or "0")
+// which was mixing list and watch calls internally and having severe design issues. (see #74022)
+// There is no resourceVersion order guarantee for the initial list and those synthetic events.
+func ListWatchUntil(ctx context.Context, lw cache.ListerWatcher, conditions ...ConditionFunc) (*watch.Event, error) {
+	if len(conditions) == 0 {
+		return nil, nil
+	}
+
+	list, err := lw.List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	initialItems, err := meta.ExtractList(list)
+	if err != nil {
+		return nil, err
+	}
+
+	// use the initial items as simulated "adds"
+	var lastEvent *watch.Event
+	currIndex := 0
+	passedConditions := 0
+	for _, condition := range conditions {
+		// check the next condition against the previous event and short circuit waiting for the next watch
+		if lastEvent != nil {
+			done, err := condition(*lastEvent)
+			if err != nil {
+				return lastEvent, err
+			}
+			if done {
+				passedConditions = passedConditions + 1
+				continue
+			}
+		}
+
+	ConditionSucceeded:
+		for currIndex < len(initialItems) {
+			lastEvent = &watch.Event{Type: watch.Added, Object: initialItems[currIndex]}
+			currIndex++
+
+			done, err := condition(*lastEvent)
+			if err != nil {
+				return lastEvent, err
+			}
+			if done {
+				passedConditions = passedConditions + 1
+				break ConditionSucceeded
+			}
+		}
+	}
+	if passedConditions == len(conditions) {
+		return lastEvent, nil
+	}
+	remainingConditions := conditions[passedConditions:]
+
+	metaObj, err := meta.ListAccessor(list)
+	if err != nil {
+		return nil, err
+	}
+	currResourceVersion := metaObj.GetResourceVersion()
+
+	return Until(ctx, currResourceVersion, lw, remainingConditions...)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -179,11 +179,12 @@ github.com/openshift/api/pkg/serialization
 github.com/openshift/api/image/docker10
 github.com/openshift/api/image/dockerpre012
 # github.com/openshift/client-go v0.0.0-20190617165122-8892c0adc000
+github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1
 github.com/openshift/client-go/config/clientset/versioned
 github.com/openshift/client-go/config/informers/externalversions
 github.com/openshift/client-go/operator/clientset/versioned
 github.com/openshift/client-go/operator/informers/externalversions
-github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1
+github.com/openshift/client-go/operator/clientset/versioned/scheme
 github.com/openshift/client-go/config/clientset/versioned/typed/config/v1
 github.com/openshift/client-go/config/informers/externalversions/config
 github.com/openshift/client-go/config/informers/externalversions/internalinterfaces
@@ -191,7 +192,6 @@ github.com/openshift/client-go/operator/informers/externalversions/internalinter
 github.com/openshift/client-go/operator/informers/externalversions/operator
 github.com/openshift/client-go/config/informers/externalversions/config/v1
 github.com/openshift/client-go/config/listers/config/v1
-github.com/openshift/client-go/operator/clientset/versioned/scheme
 github.com/openshift/client-go/config/clientset/versioned/scheme
 github.com/openshift/client-go/operator/informers/externalversions/operator/v1
 github.com/openshift/client-go/operator/listers/operator/v1
@@ -202,6 +202,7 @@ github.com/openshift/library-go/pkg/operator/resource/resourcemerge
 github.com/openshift/library-go/pkg/operator/events
 github.com/openshift/library-go/pkg/operator/status
 github.com/openshift/library-go/pkg/operator/v1helpers
+github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers
 github.com/openshift/library-go/pkg/operator/resourcesynccontroller
 github.com/openshift/library-go/pkg/operator/configobserver
 github.com/openshift/library-go/pkg/crypto
@@ -212,7 +213,6 @@ github.com/openshift/library-go/pkg/config/serving
 github.com/openshift/library-go/pkg/controller/fileobserver
 github.com/openshift/library-go/pkg/controller/metrics
 github.com/openshift/library-go/pkg/serviceability
-github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers
 github.com/openshift/library-go/pkg/operator/management
 github.com/openshift/library-go/pkg/operator/resource/resourceapply
 github.com/openshift/library-go/pkg/operator/condition
@@ -392,10 +392,12 @@ k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme
 # k8s.io/apimachinery v0.0.0-20190313205120-d7deff9243b1
 k8s.io/apimachinery/pkg/runtime/schema
 k8s.io/apimachinery/pkg/util/wait
-k8s.io/apimachinery/pkg/util/runtime
-k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/apis/meta/v1
 k8s.io/apimachinery/pkg/apis/meta/v1/unstructured
+k8s.io/apimachinery/pkg/util/runtime
+k8s.io/apimachinery/pkg/api/errors
+k8s.io/apimachinery/pkg/fields
+k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/pkg/util/sets
 k8s.io/apimachinery/pkg/version
 k8s.io/apimachinery/pkg/runtime
@@ -403,23 +405,21 @@ k8s.io/apimachinery/pkg/runtime/serializer
 k8s.io/apimachinery/pkg/util/yaml
 k8s.io/apimachinery/pkg/util/errors
 k8s.io/apimachinery/pkg/api/equality
-k8s.io/apimachinery/pkg/watch
-k8s.io/apimachinery/pkg/runtime/serializer/streaming
 k8s.io/apimachinery/pkg/types
+k8s.io/apimachinery/pkg/api/resource
+k8s.io/apimachinery/pkg/conversion
+k8s.io/apimachinery/pkg/labels
+k8s.io/apimachinery/pkg/selection
+k8s.io/apimachinery/pkg/util/intstr
+k8s.io/apimachinery/pkg/util/json
+k8s.io/apimachinery/pkg/runtime/serializer/streaming
 k8s.io/apimachinery/pkg/util/net
 k8s.io/apimachinery/pkg/api/meta
-k8s.io/apimachinery/pkg/fields
-k8s.io/apimachinery/pkg/labels
 k8s.io/apimachinery/pkg/util/cache
 k8s.io/apimachinery/pkg/util/clock
 k8s.io/apimachinery/pkg/util/diff
 k8s.io/apimachinery/pkg/util/naming
 k8s.io/apimachinery/pkg/util/validation/field
-k8s.io/apimachinery/pkg/api/resource
-k8s.io/apimachinery/pkg/conversion
-k8s.io/apimachinery/pkg/selection
-k8s.io/apimachinery/pkg/util/intstr
-k8s.io/apimachinery/pkg/util/json
 k8s.io/apimachinery/pkg/util/rand
 k8s.io/apimachinery/pkg/conversion/queryparams
 k8s.io/apimachinery/pkg/runtime/serializer/json
@@ -430,9 +430,9 @@ k8s.io/apimachinery/pkg/util/uuid
 k8s.io/apimachinery/pkg/util/validation
 k8s.io/apimachinery/pkg/util/waitgroup
 k8s.io/apimachinery/pkg/util/strategicpatch
+k8s.io/apimachinery/third_party/forked/golang/reflect
 k8s.io/apimachinery/pkg/apis/meta/v1beta1
 k8s.io/apimachinery/pkg/apis/meta/internalversion
-k8s.io/apimachinery/third_party/forked/golang/reflect
 k8s.io/apimachinery/pkg/util/framer
 k8s.io/apimachinery/pkg/api/validation/path
 k8s.io/apimachinery/pkg/api/validation
@@ -542,6 +542,7 @@ k8s.io/client-go/kubernetes
 k8s.io/client-go/rest
 k8s.io/client-go/tools/cache
 k8s.io/client-go/util/workqueue
+k8s.io/client-go/tools/watch
 k8s.io/client-go/util/retry
 k8s.io/client-go/listers/core/v1
 k8s.io/client-go/tools/leaderelection


### PR DESCRIPTION
Add bootstrapteardown/teardown.go which watches on clusterversions.
The installer watches on clusterversions to wait for the installation
to complete. We use the same mechanism so removing the bootstrap from
ceo and removing the resources in installer are both triggered on
clusterversions reporting install complete and are executed at about
the same time preventing excessive etcd logging.