### PR TITLE
*: add hostendpointcontroller, refactor to wait for cache to sync

### DIFF
--- a/pkg/cmd/mount/mount.go
+++ b/pkg/cmd/mount/mount.go
@@ -2,13 +2,14 @@ package mount
 
 import (
 	"fmt"
-	"github.com/spf13/pflag"
 	"io"
 	"io/ioutil"
-	"k8s.io/klog"
 	"path"
 	"strings"
 	"time"
+
+	"github.com/spf13/pflag"
+	"k8s.io/klog"
 
 	"github.com/spf13/cobra"
 	v1 "k8s.io/api/core/v1"

--- a/pkg/operator/hostetcdendpointcontroller/hostendpointcontroller.go
+++ b/pkg/operator/hostetcdendpointcontroller/hostendpointcontroller.go
@@ -1,0 +1,211 @@
+package hostetcdendpointcontroller
+
+import (
+	"fmt"
+	"math/rand"
+	"strconv"
+	"time"
+
+	"github.com/openshift/cluster-etcd-operator/pkg/operator/clustermembercontroller"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	corev1client "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog"
+)
+
+const (
+	workQueueKey = "key"
+	subnetPrefix = "192.0.2."
+	maxIPAddress = 255
+)
+
+type HostEtcdEndpointController struct {
+	clientset                              corev1client.Interface
+	operatorConfigClient                   v1helpers.OperatorClient
+	queue                                  workqueue.RateLimitingInterface
+	kubeInformersForOpenshiftEtcdnamespace informers.SharedInformerFactory
+	healthyEtcdMemberGetter                HealthyEtcdMembersGetter
+	eventRecorder                          events.Recorder
+}
+
+func NewHostEtcdEndpointcontroller(
+	clientset corev1client.Interface,
+	operatorConfigClient v1helpers.OperatorClient,
+
+	kubeInformersForOpenshiftEtcdNamespace informers.SharedInformerFactory,
+	eventRecorder events.Recorder,
+) *HostEtcdEndpointController {
+	h := &HostEtcdEndpointController{
+		clientset:                              clientset,
+		operatorConfigClient:                   operatorConfigClient,
+		queue:                                  workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "HostEtcdEndpointController"),
+		kubeInformersForOpenshiftEtcdnamespace: kubeInformersForOpenshiftEtcdNamespace,
+		healthyEtcdMemberGetter:                NewHealthyEtcdMemberGetter(operatorConfigClient),
+		eventRecorder:                          eventRecorder.WithComponentSuffix("host-etcd-endpoint-controller"),
+	}
+	operatorConfigClient.Informer().AddEventHandler(h.eventHandler())
+	h.kubeInformersForOpenshiftEtcdnamespace.Core().V1().Endpoints().Informer().AddEventHandler(h.eventHandler())
+	//TODO: remove this when liveness probe is added to etcd-member.yaml.
+	h.kubeInformersForOpenshiftEtcdnamespace.Core().V1().Pods().Informer().AddEventHandler(h.eventHandler())
+	return h
+}
+
+func (h *HostEtcdEndpointController) Run(i int, stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	defer h.queue.ShutDown()
+
+	klog.Infof("Starting ClusterMemberController")
+	defer klog.Infof("Shutting down ClusterMemberController")
+
+	if !cache.WaitForCacheSync(stopCh,
+		h.operatorConfigClient.Informer().HasSynced,
+		h.kubeInformersForOpenshiftEtcdnamespace.Core().V1().Endpoints().Informer().HasSynced,
+		h.kubeInformersForOpenshiftEtcdnamespace.Core().V1().Pods().Informer().HasSynced) {
+		utilruntime.HandleError(fmt.Errorf("caches did not sync"))
+		return
+	}
+
+	go wait.Until(h.runWorker, time.Second, stopCh)
+
+	<-stopCh
+}
+
+func (h *HostEtcdEndpointController) runWorker() {
+	for h.processNextWorkItem() {
+	}
+}
+
+func (h *HostEtcdEndpointController) processNextWorkItem() bool {
+	dsKey, quit := h.queue.Get()
+	if quit {
+		return false
+	}
+	defer h.queue.Done(dsKey)
+
+	err := h.sync()
+	if err == nil {
+		h.queue.Forget(dsKey)
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
+	h.queue.AddRateLimited(dsKey)
+
+	return true
+}
+
+func (h *HostEtcdEndpointController) eventHandler() cache.ResourceEventHandler {
+	// eventHandler queues the operator to check spec and status
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { h.queue.Add(workQueueKey) },
+		UpdateFunc: func(old, new interface{}) { h.queue.Add(workQueueKey) },
+		DeleteFunc: func(obj interface{}) { h.queue.Add(workQueueKey) },
+	}
+}
+
+func (h *HostEtcdEndpointController) sync() error {
+	ep, err := h.clientset.CoreV1().Endpoints(clustermembercontroller.EtcdEndpointNamespace).
+		Get(clustermembercontroller.EtcdHostEndpointName, v1.GetOptions{})
+	if err != nil {
+		klog.Errorf("error getting %s/%s endpoint: %#v",
+			clustermembercontroller.EtcdEndpointNamespace,
+			clustermembercontroller.EtcdEndpointName,
+			err,
+		)
+		return err
+	}
+	if len(ep.Subsets) != 1 {
+		klog.Errorf("length of host endpoint subset is not equal to 1")
+		return fmt.Errorf("unexpected length of host endpoint subset")
+	}
+
+	newSubset, err := h.getNewAddressSubset(ep.Subsets[0].Addresses)
+	if err != nil {
+		klog.Errorf("error getting new address subset: %#v", err)
+	}
+
+	ep.Subsets[0].Addresses = newSubset
+	_, err = h.clientset.CoreV1().Endpoints(clustermembercontroller.EtcdEndpointNamespace).Update(ep)
+	return err
+}
+
+func (h *HostEtcdEndpointController) getNewAddressSubset(addresses []corev1.EndpointAddress) ([]corev1.EndpointAddress, error) {
+	hostnames := make([]string, len(addresses))
+	ipAddresses := make([]string, len(addresses))
+	for _, h := range addresses {
+		hostnames = append(hostnames, h.Hostname)
+		ipAddresses = append(ipAddresses, h.IP)
+	}
+	healthyMembers, err := h.healthyEtcdMemberGetter.GetHealthyEtcdMembers()
+	if err != nil {
+		return nil, err
+	}
+	add, remove := diff(hostnames, healthyMembers)
+
+	newSubset := []corev1.EndpointAddress{}
+
+	for _, h := range addresses {
+		if ok := in(remove, h.Hostname); !ok {
+			newSubset = append(newSubset, h)
+		}
+	}
+
+	//  Since max of master etcd is 7 safe to not reuse the ip addresses of removed members.
+	newIPAddresses := pickUniqueIPAddress(ipAddresses, len(add))
+	for i, m := range add {
+		newSubset = append(newSubset, corev1.EndpointAddress{
+			IP:       newIPAddresses[i],
+			Hostname: m,
+		})
+	}
+	return newSubset, nil
+}
+
+func pickUniqueIPAddress(assignedIPAddresses []string, newIPAddressNeeded int) []string {
+	ipAddresses := make([]string, len(assignedIPAddresses))
+	newIPAddresses := make([]string, newIPAddressNeeded)
+	copy(ipAddresses, assignedIPAddresses)
+	src := rand.NewSource(time.Now().Unix())
+	r := rand.New(src)
+	for i := 0; i < newIPAddressNeeded; i++ {
+		tryIP := subnetPrefix + strconv.Itoa(r.Intn(maxIPAddress))
+		for ok := in(ipAddresses, tryIP); ok; {
+			tryIP = subnetPrefix + strconv.Itoa(r.Intn(maxIPAddress))
+			ok = in(ipAddresses, tryIP)
+		}
+		newIPAddresses[i] = tryIP
+		ipAddresses = append(ipAddresses, tryIP)
+	}
+	return newIPAddresses
+}
+
+func diff(hostnames, healthyMembers []string) (add, remove []string) {
+	for _, h := range hostnames {
+		if ok := in(healthyMembers, h); !ok {
+			remove = append(remove, h)
+		}
+	}
+
+	for _, m := range healthyMembers {
+		if ok := in(hostnames, m); !ok {
+			add = append(add, m)
+		}
+	}
+	return
+}
+
+func in(list []string, member string) bool {
+	for _, element := range list {
+		if element == member {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/operator/hostetcdendpointcontroller/hostendpointcontroller.go
+++ b/pkg/operator/hostetcdendpointcontroller/hostendpointcontroller.go
@@ -189,6 +189,9 @@ func pickUniqueIPAddress(assignedIPAddresses []string, newIPAddressNeeded int) [
 func diff(hostnames, healthyMembers []string) (add, remove []string) {
 	for _, h := range hostnames {
 		if ok := in(healthyMembers, h); !ok {
+			if h == "etcd-bootstrap" {
+				continue
+			}
 			remove = append(remove, h)
 		}
 	}

--- a/pkg/operator/hostetcdendpointcontroller/hostendpointcontroller_test.go
+++ b/pkg/operator/hostetcdendpointcontroller/hostendpointcontroller_test.go
@@ -1,0 +1,243 @@
+package hostetcdendpointcontroller
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func Test_diff(t *testing.T) {
+	type args struct {
+		hostnames      []string
+		healthyMembers []string
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantAdd    []string
+		wantRemove []string
+	}{
+		{
+			name: "only etcd-bootstrap",
+			args: args{
+				hostnames:      []string{"etcd-bootstrap"},
+				healthyMembers: []string{"etcd-bootstrap"},
+			},
+			wantAdd:    nil,
+			wantRemove: nil,
+		},
+		{
+			name: "scaling: add a member after etcd-bootstrap",
+			args: args{
+				hostnames:      []string{"etcd-bootstrap"},
+				healthyMembers: []string{"etcd-bootstrap", "etcd-0"},
+			},
+			wantAdd:    []string{"etcd-0"},
+			wantRemove: nil,
+		},
+		{
+			name: "scaling: add second member after etcd-bootstrap and etcd-0",
+			args: args{
+				hostnames:      []string{"etcd-bootstrap", "etcd-0"},
+				healthyMembers: []string{"etcd-bootstrap", "etcd-0", "etcd-1"},
+			},
+			wantAdd:    []string{"etcd-1"},
+			wantRemove: nil,
+		},
+		{
+			name: "scaling: remove etcd-bootstrap member",
+			args: args{
+				hostnames:      []string{"etcd-bootstrap", "etcd-0", "etcd-1"},
+				healthyMembers: []string{"etcd-0", "etcd-1"},
+			},
+			wantAdd:    nil,
+			wantRemove: []string{"etcd-bootstrap"},
+		},
+		{
+			name: "scaling: remove etcd-bootstrap member and add etcd-2 at the same time",
+			args: args{
+				hostnames:      []string{"etcd-bootstrap", "etcd-0", "etcd-1"},
+				healthyMembers: []string{"etcd-0", "etcd-1", "etcd-2"},
+			},
+			wantAdd:    []string{"etcd-2"},
+			wantRemove: []string{"etcd-bootstrap"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotAdd, gotRemove := diff(tt.args.hostnames, tt.args.healthyMembers)
+			if !reflect.DeepEqual(gotAdd, tt.wantAdd) {
+				t.Errorf("diff() gotAdd = %v, want %v", gotAdd, tt.wantAdd)
+			}
+			if !reflect.DeepEqual(gotRemove, tt.wantRemove) {
+				t.Errorf("diff() gotRemove = %v, want %v", gotRemove, tt.wantRemove)
+			}
+		})
+	}
+}
+
+func Test_pickIpAddress(t *testing.T) {
+	type args struct {
+		assignedIPAddresses []string
+		newIPAddressNeeded  int
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "case scaling from etcd-bootstrap",
+			args: args{
+				assignedIPAddresses: []string{subnetPrefix + "1"},
+				newIPAddressNeeded:  2,
+			},
+		},
+		{
+			name: "case scaline from 2 nodes",
+			args: args{
+				assignedIPAddresses: []string{subnetPrefix + "102", subnetPrefix + "114"},
+				newIPAddressNeeded:  3,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := pickUniqueIPAddress(tt.args.assignedIPAddresses, tt.args.newIPAddressNeeded)
+			if len(got) != tt.args.newIPAddressNeeded {
+				t.Fatalf("got %d, needed %d", len(got), tt.args.newIPAddressNeeded)
+			}
+			for _, ip := range got {
+				if ok := in(tt.args.assignedIPAddresses, ip); ok {
+					t.Fatalf("ip %s in already asigned %#v", ip, tt.args.assignedIPAddresses)
+				}
+				tt.args.assignedIPAddresses = append(tt.args.assignedIPAddresses, ip)
+			}
+		})
+	}
+}
+
+type fakeEtcdMemberGetter []string
+
+func (f fakeEtcdMemberGetter) GetHealthyEtcdMembers() ([]string, error) {
+	return f, nil
+}
+
+func TestHostEtcdEndpointController_getNewAddressSubset(t *testing.T) {
+	type fields struct {
+		healthyEtcdMemberGetter HealthyEtcdMembersGetter
+	}
+	type args struct {
+		addresses []corev1.EndpointAddress
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    []corev1.EndpointAddress
+		wantErr bool
+	}{
+		{
+			name:   "scaling up from bootstrap",
+			fields: fields{healthyEtcdMemberGetter: fakeEtcdMemberGetter{"etcd-bootstrap", "etcd-0", "etcd-1"}},
+			args: args{addresses: []corev1.EndpointAddress{
+				{
+					Hostname: "etcd-boostrap",
+					IP:       subnetPrefix + "1",
+				},
+			}},
+			want: []corev1.EndpointAddress{
+				{
+					Hostname: "etcd-bootstrap",
+					IP:       subnetPrefix + "1",
+				},
+				{
+					Hostname: "etcd-0",
+				},
+				{
+					Hostname: "etcd-1",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:   "scaling down etcd-bootstrap",
+			fields: fields{healthyEtcdMemberGetter: fakeEtcdMemberGetter{"etcd-0", "etcd-1"}},
+			args: args{addresses: []corev1.EndpointAddress{
+				{
+					Hostname: "etcd-boostrap",
+					IP:       subnetPrefix + "1",
+				},
+				{
+					Hostname: "etcd-0",
+					IP:       subnetPrefix + "2",
+				},
+				{
+					Hostname: "etcd-1",
+					IP:       subnetPrefix + "3",
+				},
+			}},
+			want: []corev1.EndpointAddress{
+				{
+					Hostname: "etcd-0",
+				},
+				{
+					Hostname: "etcd-1",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:   "scaling down etcd-bootstrap and scale another member at the same time",
+			fields: fields{healthyEtcdMemberGetter: fakeEtcdMemberGetter{"etcd-0", "etcd-1", "etcd-2"}},
+			args: args{addresses: []corev1.EndpointAddress{
+				{
+					Hostname: "etcd-boostrap",
+					IP:       subnetPrefix + "1",
+				},
+				{
+					Hostname: "etcd-0",
+					IP:       subnetPrefix + "2",
+				},
+				{
+					Hostname: "etcd-1",
+					IP:       subnetPrefix + "3",
+				},
+			}},
+			want: []corev1.EndpointAddress{
+				{
+					Hostname: "etcd-0",
+				},
+				{
+					Hostname: "etcd-1",
+				},
+				{
+					Hostname: "etcd-2",
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &HostEtcdEndpointController{
+				healthyEtcdMemberGetter: tt.fields.healthyEtcdMemberGetter,
+			}
+			got, err := h.getNewAddressSubset(tt.args.addresses)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getNewAddressSubset() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if len(got) != len(tt.want) {
+				t.Errorf("getNewAddressSubset() got length = %v, want length %v", len(got), len(tt.want))
+				return
+			}
+			for i, addr := range got {
+				if addr.Hostname != tt.want[i].Hostname {
+					t.Errorf("for index %d want hostname  %v, got  %v", i, addr.Hostname, tt.want[i].Hostname)
+					return
+				}
+			}
+		})
+	}
+}

--- a/pkg/operator/hostetcdendpointcontroller/hostendpointcontroller_test.go
+++ b/pkg/operator/hostetcdendpointcontroller/hostendpointcontroller_test.go
@@ -46,22 +46,22 @@ func Test_diff(t *testing.T) {
 			wantRemove: nil,
 		},
 		{
-			name: "scaling: remove etcd-bootstrap member",
+			name: "scaling: ignore etcd-bootstrap member",
 			args: args{
 				hostnames:      []string{"etcd-bootstrap", "etcd-0", "etcd-1"},
 				healthyMembers: []string{"etcd-0", "etcd-1"},
 			},
 			wantAdd:    nil,
-			wantRemove: []string{"etcd-bootstrap"},
+			wantRemove: nil,
 		},
 		{
-			name: "scaling: remove etcd-bootstrap member and add etcd-2 at the same time",
+			name: "scaling: add etcd-2 at the same time",
 			args: args{
 				hostnames:      []string{"etcd-bootstrap", "etcd-0", "etcd-1"},
 				healthyMembers: []string{"etcd-0", "etcd-1", "etcd-2"},
 			},
 			wantAdd:    []string{"etcd-2"},
-			wantRemove: []string{"etcd-bootstrap"},
+			wantRemove: nil,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/operator/hostetcdendpointcontroller/members.go
+++ b/pkg/operator/hostetcdendpointcontroller/members.go
@@ -1,0 +1,136 @@
+package hostetcdendpointcontroller
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/pkg/transport"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/klog"
+
+	ceoapi "github.com/openshift/cluster-etcd-operator/pkg/operator/api"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+const (
+	etcdCertFile      = "/var/run/secrets/etcd-client/tls.crt"
+	etcdKeyFile       = "/var/run/secrets/etcd-client/tls.key"
+	etcdTrustedCAFile = "/var/run/configmaps/etcd-ca/ca-bundle.crt"
+)
+
+type HealthyEtcdMembersGetter interface {
+	GetHealthyEtcdMembers() ([]string, error)
+}
+
+type healthyEtcdMemberGetter struct {
+	operatorConfigClient v1helpers.OperatorClient
+}
+
+func NewHealthyEtcdMemberGetter(operatorConfigClient v1helpers.OperatorClient) HealthyEtcdMembersGetter {
+	return &healthyEtcdMemberGetter{operatorConfigClient}
+}
+
+func (h *healthyEtcdMemberGetter) GetHealthyEtcdMembers() ([]string, error) {
+	member, err := h.EtcdList("members")
+	if err != nil {
+		return nil, err
+	}
+	hostnames := make([]string, 0)
+	for _, m := range member {
+		hostname := getEtcdName(m.PeerURLS)
+		hostnames = append(hostnames, hostname)
+	}
+	return hostnames, nil
+}
+
+func getEtcdName(peerURLs []string) string {
+	for _, peerURL := range peerURLs {
+		if strings.Contains(peerURL, "etcd-") {
+			return strings.TrimPrefix(strings.Split(peerURLs[0], ".")[0], "https://")
+		}
+	}
+	return ""
+}
+
+func (h *healthyEtcdMemberGetter) EtcdList(bucket string) ([]ceoapi.Member, error) {
+	cli, err := h.getEtcdClient()
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := cli.MemberList(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	members := make([]ceoapi.Member, len(resp.Members))
+
+	for _, m := range resp.Members {
+		statusResp, err := cli.Status(context.Background(), m.ClientURLs[0])
+		if err != nil {
+			klog.Warningf("member %s with etcdName %s is not healthy", m.Name,
+				getEtcdName(m.PeerURLs))
+			klog.Errorf("error reading %s health: %#v", m.Name, err)
+			continue
+		}
+		klog.Infof("member %s is healtly with %d index", m.Name, statusResp.RaftIndex)
+		members = append(members, ceoapi.Member{
+			Name:       m.Name,
+			PeerURLS:   m.PeerURLs,
+			ClientURLS: m.PeerURLs,
+		})
+	}
+
+	return members, nil
+}
+
+func (h *healthyEtcdMemberGetter) getEtcdClient() (*clientv3.Client, error) {
+	endpoints, err := h.Endpoints()
+	if err != nil {
+		return nil, err
+	}
+	tlsInfo := transport.TLSInfo{
+		CertFile:      etcdCertFile,
+		KeyFile:       etcdKeyFile,
+		TrustedCAFile: etcdTrustedCAFile,
+	}
+	tlsConfig, err := tlsInfo.ClientConfig()
+
+	cfg := &clientv3.Config{
+		Endpoints:   endpoints,
+		DialTimeout: 2 * time.Second,
+		TLS:         tlsConfig,
+	}
+
+	cli, err := clientv3.New(*cfg)
+	if err != nil {
+		return nil, err
+	}
+	return cli, err
+}
+
+func (h *healthyEtcdMemberGetter) Endpoints() ([]string, error) {
+	storageConfigURLsPath := []string{"storageConfig", "urls"}
+	operatorSpec, _, _, err := h.operatorConfigClient.GetOperatorState()
+	if err != nil {
+		return nil, err
+	}
+	config := map[string]interface{}{}
+	if err := json.NewDecoder(bytes.NewBuffer(operatorSpec.ObservedConfig.Raw)).Decode(&config); err != nil {
+		klog.V(4).Infof("decode of existing config failed with error: %v", err)
+	}
+	endpoints, exists, err := unstructured.NestedStringSlice(config, storageConfigURLsPath...)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, fmt.Errorf("etcd storageConfig urls not observed")
+	}
+
+	return endpoints, nil
+}

--- a/pkg/operator/hostetcdendpointcontroller/members_test.go
+++ b/pkg/operator/hostetcdendpointcontroller/members_test.go
@@ -1,0 +1,202 @@
+package hostetcdendpointcontroller
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	v1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func Test_getHostname(t *testing.T) {
+	type args struct {
+		peerURLs []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "valid test case for etcd member",
+			args: args{peerURLs: []string{"https://etcd-0.foouser.tests.com"}},
+			want: "etcd-0",
+		},
+		{
+			name: "valid test case for etcd bootstrap node",
+			args: args{peerURLs: []string{"https://etcd-bootstrap.foouser.tests.com"}},
+			want: "etcd-bootstrap",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getEtcdName(tt.args.peerURLs); got != tt.want {
+				t.Errorf("getHostname() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TODO: alaypatel07 refine the commented test with fake a etcd server.
+//func Test_healthyEtcdMemberGetter_EtcdList(t *testing.T) {
+//	node := "ip-10-0-139-142.ec2.internal"
+//	peerURL := "https://etcd-0.foouser.test.com:2380"
+//	//podIP := "10.0.139.142"
+//	clusterMemberPath := []string{"cluster", "members"}
+//
+//	var etcdURLs []interface{}
+//	observedConfig := map[string]interface{}{}
+//	etcdURL := map[string]interface{}{}
+//	if err := unstructured.SetNestedField(etcdURL, node, "name"); err != nil {
+//		t.Fatalf("error occured in writing nested fields %#v", err)
+//	}
+//	if err := unstructured.SetNestedField(etcdURL, peerURL, "peerURLs"); err != nil {
+//		t.Fatalf("error occured in writing nested fields %#v", err)
+//	}
+//
+//	if err := unstructured.SetNestedField(etcdURL, string(ceoapi.MemberUnknown), "status"); err != nil {
+//		t.Fatalf("error occured in writing nested fields observedConfig: %#v", err)
+//	}
+//
+//	etcdURLs = append(etcdURLs, etcdURL)
+//	if err := unstructured.SetNestedField(observedConfig, etcdURLs, clusterMemberPath...); err != nil {
+//		t.Fatalf("error occured in writing nested fields observedConfig: %#v", err)
+//	}
+//
+//	b := &bytes.Buffer{}
+//	e := json.NewEncoder(b)
+//	err := e.Encode(observedConfig)
+//
+//	if err != nil {
+//		t.Fatalf("err encoding observedConfig %#v", err)
+//	}
+//
+//	etcdSpec := v1.StaticPodOperatorSpec{
+//		OperatorSpec: v1.OperatorSpec{
+//			ObservedConfig: runtime.RawExtension{
+//				Raw: b.Bytes(),
+//			},
+//		},
+//	}
+//
+//	fakeOperatorClient := v1helpers.NewFakeOperatorClient(&etcdSpec.OperatorSpec, nil, nil)
+//
+//	type fields struct {
+//		operatorConfigClient v1helpers.OperatorClient
+//	}
+//	type args struct {
+//		bucket string
+//	}
+//	tests := []struct {
+//		name    string
+//		fields  fields
+//		args    args
+//		want    []ceoapi.Member
+//		wantErr bool
+//	}{
+//		{
+//			name:   "valid test case",
+//			fields: fields{operatorConfigClient: fakeOperatorClient},
+//			args:   args{bucket: "members"},
+//			want: []ceoapi.Member{
+//				{
+//					Name:     node,
+//					PeerURLS: []string{peerURL},
+//					Conditions: []ceoapi.MemberCondition{
+//						{
+//							// We can force a ReadyCondition here but because of bootstrap exception
+//							// need to relax checking of condition and assume that
+//							// all members in the cluster.members will be healthy.
+//							Type: ceoapi.MemberUnknown,
+//						},
+//					},
+//				},
+//			},
+//		},
+//	}
+//	for _, tt := range tests {
+//		t.Run(tt.name, func(t *testing.T) {
+//			h := &healthyEtcdMemberGetter{
+//				operatorConfigClient: tt.fields.operatorConfigClient,
+//			}
+//			got, err := h.EtcdList(tt.args.bucket)
+//			if (err != nil) != tt.wantErr {
+//				t.Errorf("EtcdList() error = %v, wantErr %v", err, tt.wantErr)
+//				return
+//			}
+//			if !reflect.DeepEqual(got, tt.want) {
+//				t.Errorf("EtcdList() got = %v, want %v", got, tt.want)
+//			}
+//		})
+//	}
+//}
+
+func Test_healthyEtcdMemberGetter_Endpoints(t *testing.T) {
+	storageURLs := []string{
+		"https://etcd-0.foouser.test.com:2380",
+		"https://etcd-1.foouser.test.com:2380",
+		"https://etcd-2.foouser.test.com:2380",
+	}
+
+	//podIP := "10.0.139.142"
+	storageConfigURLsPath := []string{"storageConfig", "urls"}
+
+	observedConfig := map[string]interface{}{}
+	if err := unstructured.SetNestedStringSlice(observedConfig, storageURLs, storageConfigURLsPath...); err != nil {
+		t.Fatalf("error occured in writing nested fields observedConfig: %#v", err)
+	}
+
+	b := &bytes.Buffer{}
+	e := json.NewEncoder(b)
+	err := e.Encode(observedConfig)
+
+	if err != nil {
+		t.Fatalf("err encoding observedConfig %#v", err)
+	}
+
+	etcdSpec := v1.StaticPodOperatorSpec{
+		OperatorSpec: v1.OperatorSpec{
+			ObservedConfig: runtime.RawExtension{
+				Raw: b.Bytes(),
+			},
+		},
+	}
+
+	fakeOperatorClient := v1helpers.NewFakeOperatorClient(&etcdSpec.OperatorSpec, nil, nil)
+
+	type fields struct {
+		operatorConfigClient v1helpers.OperatorClient
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    []string
+		wantErr bool
+	}{
+		{
+			name:    "valid test case",
+			fields:  fields{operatorConfigClient: fakeOperatorClient},
+			want:    storageURLs,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &healthyEtcdMemberGetter{
+				operatorConfigClient: tt.fields.operatorConfigClient,
+			}
+			got, err := h.Endpoints()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Endpoints() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Endpoints() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/operator/hostetcdendpointcontroller/members_test.go
+++ b/pkg/operator/hostetcdendpointcontroller/members_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	v1 "github.com/openshift/api/operator/v1"
+	ceoapi "github.com/openshift/cluster-etcd-operator/pkg/operator/api"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -41,112 +42,46 @@ func Test_getHostname(t *testing.T) {
 	}
 }
 
-// TODO: alaypatel07 refine the commented test with fake a etcd server.
-//func Test_healthyEtcdMemberGetter_EtcdList(t *testing.T) {
-//	node := "ip-10-0-139-142.ec2.internal"
-//	peerURL := "https://etcd-0.foouser.test.com:2380"
-//	//podIP := "10.0.139.142"
-//	clusterMemberPath := []string{"cluster", "members"}
-//
-//	var etcdURLs []interface{}
-//	observedConfig := map[string]interface{}{}
-//	etcdURL := map[string]interface{}{}
-//	if err := unstructured.SetNestedField(etcdURL, node, "name"); err != nil {
-//		t.Fatalf("error occured in writing nested fields %#v", err)
-//	}
-//	if err := unstructured.SetNestedField(etcdURL, peerURL, "peerURLs"); err != nil {
-//		t.Fatalf("error occured in writing nested fields %#v", err)
-//	}
-//
-//	if err := unstructured.SetNestedField(etcdURL, string(ceoapi.MemberUnknown), "status"); err != nil {
-//		t.Fatalf("error occured in writing nested fields observedConfig: %#v", err)
-//	}
-//
-//	etcdURLs = append(etcdURLs, etcdURL)
-//	if err := unstructured.SetNestedField(observedConfig, etcdURLs, clusterMemberPath...); err != nil {
-//		t.Fatalf("error occured in writing nested fields observedConfig: %#v", err)
-//	}
-//
-//	b := &bytes.Buffer{}
-//	e := json.NewEncoder(b)
-//	err := e.Encode(observedConfig)
-//
-//	if err != nil {
-//		t.Fatalf("err encoding observedConfig %#v", err)
-//	}
-//
-//	etcdSpec := v1.StaticPodOperatorSpec{
-//		OperatorSpec: v1.OperatorSpec{
-//			ObservedConfig: runtime.RawExtension{
-//				Raw: b.Bytes(),
-//			},
-//		},
-//	}
-//
-//	fakeOperatorClient := v1helpers.NewFakeOperatorClient(&etcdSpec.OperatorSpec, nil, nil)
-//
-//	type fields struct {
-//		operatorConfigClient v1helpers.OperatorClient
-//	}
-//	type args struct {
-//		bucket string
-//	}
-//	tests := []struct {
-//		name    string
-//		fields  fields
-//		args    args
-//		want    []ceoapi.Member
-//		wantErr bool
-//	}{
-//		{
-//			name:   "valid test case",
-//			fields: fields{operatorConfigClient: fakeOperatorClient},
-//			args:   args{bucket: "members"},
-//			want: []ceoapi.Member{
-//				{
-//					Name:     node,
-//					PeerURLS: []string{peerURL},
-//					Conditions: []ceoapi.MemberCondition{
-//						{
-//							// We can force a ReadyCondition here but because of bootstrap exception
-//							// need to relax checking of condition and assume that
-//							// all members in the cluster.members will be healthy.
-//							Type: ceoapi.MemberUnknown,
-//						},
-//					},
-//				},
-//			},
-//		},
-//	}
-//	for _, tt := range tests {
-//		t.Run(tt.name, func(t *testing.T) {
-//			h := &healthyEtcdMemberGetter{
-//				operatorConfigClient: tt.fields.operatorConfigClient,
-//			}
-//			got, err := h.EtcdList(tt.args.bucket)
-//			if (err != nil) != tt.wantErr {
-//				t.Errorf("EtcdList() error = %v, wantErr %v", err, tt.wantErr)
-//				return
-//			}
-//			if !reflect.DeepEqual(got, tt.want) {
-//				t.Errorf("EtcdList() got = %v, want %v", got, tt.want)
-//			}
-//		})
-//	}
-//}
+func Test_healthyEtcdMemberGetter_EtcdList(t *testing.T) {
+	node := "node1"
+	peerURL := "https://etcd-0.foouser.test.com:2380"
+	bootstrapNode := "etcd-bootstrap"
+	bootstrapPeerUrl := "https://etcd-bootstrap.foouser.test.com:2380"
+	//podIP := "10.0.139.142"
+	clusterMemberPath := []string{"cluster", "members"}
 
-func Test_healthyEtcdMemberGetter_Endpoints(t *testing.T) {
-	storageURLs := []string{
-		"https://etcd-0.foouser.test.com:2380",
-		"https://etcd-1.foouser.test.com:2380",
-		"https://etcd-2.foouser.test.com:2380",
+	var etcdURLs []interface{}
+	observedConfig := map[string]interface{}{}
+	etcdURL := map[string]interface{}{}
+	if err := unstructured.SetNestedField(etcdURL, node, "name"); err != nil {
+		t.Fatalf("error occured in writing nested fields %#v", err)
 	}
 
-	//podIP := "10.0.139.142"
-	storageConfigURLsPath := []string{"storageConfig", "urls"}
+	if err := unstructured.SetNestedField(etcdURL, peerURL, "peerURLs"); err != nil {
+		t.Fatalf("error occured in writing nested fields %#v", err)
+	}
 
-	observedConfig := map[string]interface{}{}
-	if err := unstructured.SetNestedStringSlice(observedConfig, storageURLs, storageConfigURLsPath...); err != nil {
+	if err := unstructured.SetNestedField(etcdURL, string(ceoapi.MemberReady), "status"); err != nil {
+		t.Fatalf("error occured in writing nested fields observedConfig: %#v", err)
+	}
+
+	etcdURLs = append(etcdURLs, etcdURL)
+	etcdBootstrapURL := map[string]interface{}{}
+	if err := unstructured.SetNestedField(etcdBootstrapURL, bootstrapNode, "name"); err != nil {
+		t.Fatalf("error occured in writing nested fields %#v", err)
+	}
+
+	if err := unstructured.SetNestedField(etcdBootstrapURL, bootstrapPeerUrl, "peerURLs"); err != nil {
+		t.Fatalf("error occured in writing nested fields %#v", err)
+	}
+
+	if err := unstructured.SetNestedField(etcdBootstrapURL, string(ceoapi.MemberReady), "status"); err != nil {
+		t.Fatalf("error occured in writing nested fields observedConfig: %#v", err)
+	}
+
+	etcdURLs = append(etcdURLs, etcdBootstrapURL)
+
+	if err := unstructured.SetNestedField(observedConfig, etcdURLs, clusterMemberPath...); err != nil {
 		t.Fatalf("error occured in writing nested fields observedConfig: %#v", err)
 	}
 
@@ -171,17 +106,40 @@ func Test_healthyEtcdMemberGetter_Endpoints(t *testing.T) {
 	type fields struct {
 		operatorConfigClient v1helpers.OperatorClient
 	}
+	type args struct {
+		bucket string
+	}
 	tests := []struct {
 		name    string
 		fields  fields
-		want    []string
+		args    args
+		want    []ceoapi.Member
 		wantErr bool
 	}{
 		{
-			name:    "valid test case",
-			fields:  fields{operatorConfigClient: fakeOperatorClient},
-			want:    storageURLs,
-			wantErr: false,
+			name:   "valid test case",
+			fields: fields{operatorConfigClient: fakeOperatorClient},
+			args:   args{bucket: "members"},
+			want: []ceoapi.Member{
+				{
+					Name:     node,
+					PeerURLS: []string{peerURL},
+					Conditions: []ceoapi.MemberCondition{
+						{
+							Type: ceoapi.MemberReady,
+						},
+					},
+				},
+				{
+					Name:     bootstrapNode,
+					PeerURLS: []string{bootstrapPeerUrl},
+					Conditions: []ceoapi.MemberCondition{
+						{
+							Type: ceoapi.MemberReady,
+						},
+					},
+				},
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -189,13 +147,13 @@ func Test_healthyEtcdMemberGetter_Endpoints(t *testing.T) {
 			h := &healthyEtcdMemberGetter{
 				operatorConfigClient: tt.fields.operatorConfigClient,
 			}
-			got, err := h.Endpoints()
+			got, err := h.EtcdList(tt.args.bucket)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("Endpoints() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("EtcdList() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Endpoints() got = %v, want %v", got, tt.want)
+				t.Errorf("EtcdList() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/openshift/cluster-etcd-operator/pkg/operator/hostetcdendpointcontroller"
+
 	"k8s.io/klog"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -122,6 +124,12 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 		kubeInformersForNamespaces.InformersFor("openshift-etcd"),
 		ctx.EventRecorder,
 	)
+	hostEtcdEndpointController := hostetcdendpointcontroller.NewHostEtcdEndpointcontroller(
+		coreClient,
+		operatorClient,
+		kubeInformersForNamespaces.InformersFor("openshift-etcd"),
+		ctx.EventRecorder,
+	)
 
 	clusterMemberController := clustermembercontroller.NewClusterMemberController(
 		coreClient,
@@ -135,6 +143,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 	configInformers.Start(ctx.Done())
 
 	go etcdCertSignerController.Run(1, ctx.Done())
+	go hostEtcdEndpointController.Run(1, ctx.Done())
 	go resourceSyncController.Run(1, ctx.Done())
 	go configObserver.Run(1, ctx.Done())
 	go clusterOperatorStatus.Run(1, ctx.Done())


### PR DESCRIPTION
* Add hostetcdendpointcontroller:
* wait for caches to sync in the controllers
* refactor by running go imports

The `hostetcdendpointcontroller` watches on cluster etcd CRD, 
endpoints and pods in etcd namespace. It reconciles by running a
diff on actual number of members observed by etcd api with 
members in the endpoint list.

Querying the etcd membership is necessary here because all the
controllers in this project depends on the endpoints being the source of
truth. If the endpoint list is based on other things like
cluster.members data in etcd, it creates a cyclic dependency and is
not necessarily accurate.
